### PR TITLE
Fixes Debian Flavor support

### DIFF
--- a/betterdiscordctl
+++ b/betterdiscordctl
@@ -109,12 +109,12 @@ while :; do
       ;;
     -f|--flavors)
       if [ "$2" ]; then
-        readarray -td, flavors <<< "$2,"; unset 'flavors[-1]'
+        read -at flavors <<< "$2,"; unset 'flavors[-1]'
         shift
       else die_non_empty '--flavors'; fi
       ;;
     --flavors=?*)
-      readarray -td, flavors <<< "${1#*=},"; unset 'flavors[-1]'
+      read -at flavors <<< "${1#*=},"; unset 'flavors[-1]'
       ;;
     --flavors=)
       die_non_empty '--flavors'


### PR DESCRIPTION
use read -at to get around lack of -d argument in readarray[note, this removes -d completely so it might not parse array right but it allows script to continue]

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bb010g/betterdiscordctl/4)
<!-- Reviewable:end -->
