### PR TITLE
Fix debian requirement of --scan

### DIFF
--- a/betterdiscordctl
+++ b/betterdiscordctl
@@ -277,7 +277,7 @@ if [[ $cmd != upgrade ]]; then
       for flavor in "${flavors[@]}"; do
         verbose 2 "VV: Trying flavor '$flavor'"
         shopt -s nocaseglob
-        for discord in "$scan"/discord?(-)"$flavor"; do
+        for discord in "$scandir"/discord?(-)"$flavor"; do
           shopt -u nocaseglob
           if [[ -d $discord ]]; then
             verbose 1 "V: Using Discord at $discord"


### PR DESCRIPTION
changes the variable on line 280 to match the variable that is recursed through the directory (previously was stuck as /opt since that is what $scan was, $scandir is the variable it was expecting.
fixes #10

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bb010g/betterdiscordctl/40)
<!-- Reviewable:end -->
