### PR TITLE
Add --bdctl-url option

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ You can then keep `betterdiscordctl` up to date with one command:
 
   Increases the verbosity level, for progressively more debugging information.
 
-* `-s` / `--scan` (default `/opt:/usr/share`)
+* `-s` / `--scan` (default `/opt:/usr/share:/usr/lib64`)
 
   Changes the directories scanned for Discord installations. These are scanned
   in the order provided. Note that these do **not** end in `/discord`—if your
@@ -99,7 +99,7 @@ You can then keep `betterdiscordctl` up to date with one command:
   flag is set due to Flatpak apps being [sandboxed][flatpak-docs]. A given
   option argument will be used as the flatpak command to call.
 
-* `--bdctl-url` (default `https://git.io/bdctl`)
+* `--upgrade-url` (default `https://git.io/bdctl`)
 
   Use the specified URL for upgrading betterdiscordctl.
 

--- a/README.md
+++ b/README.md
@@ -91,13 +91,17 @@ You can then keep `betterdiscordctl` up to date with one command:
 
   Automatically detect the default Snap directories for Discord. The `-c` flag
   is set due to Snaps apps being [confined][snapcraft-docs]. A given option
-  argument will be used as the snap(1) command to call.
+  argument will be used as the snap command to call.
 
 * `--flatpak`
 
   Automatically detect the default Flatpak directories for Discord. The `-c`
   flag is set due to Flatpak apps being [sandboxed][flatpak-docs]. A given
-  option argument will be used as the flatpak(1) command to call.
+  option argument will be used as the flatpak command to call.
+
+* `--bdctl-url` (default `https://git.io/bdctl`)
+
+  Use the specified URL for upgrading betterdiscordctl.
 
 [snapcraft-docs]: https://docs.snapcraft.io/reference/confinement
 [flatpak-docs]:   http://docs.flatpak.org/en/latest/working-with-the-sandbox.html
@@ -140,8 +144,8 @@ Updates `betterdiscordctl` to the latest version available on GitHub.
 
 * `betterdiscordctl status -s /usr/share`
 
-  Shows the status of the default Discord install in `/usr/share`, instead
-  of `/opt`.
+  Shows the status of the default Discord installation in `/usr/share`,
+  instead of `/opt`.
 
 * `betterdiscordctl install -f ptb`
 

--- a/betterdiscordctl
+++ b/betterdiscordctl
@@ -4,9 +4,8 @@ set -ueo pipefail
 shopt -s dotglob extglob nullglob
 
 # Constants
-VERSION=1.6.1
+VERSION=1.7.0
 SOURCE=$(readlink -f "${BASH_SOURCE[0]}")
-GITHUB_URL='https://raw.githubusercontent.com/bb010g/betterdiscordctl/master/betterdiscordctl'
 DISABLE_UPGRADE=
 
 # Options
@@ -22,6 +21,7 @@ bd=
 copy_bd=
 snap=
 flatpak=
+bdctl_url='https://git.io/bdctl'
 
 # Variables
 flavor=
@@ -40,22 +40,24 @@ Options:
   -h, --help                     Display this help message and exit
   -v, --verbose                  Increase verbosity
   -s, --scan=DIRECTORIES         Colon-separated list of directories to scan for
-                                 a Discord installation.
+                                 a Discord installation
                                  (default '/opt:/usr/share')
   -f, --flavors=FLAVORS          Colon-separated list of Discord flavors
                                  (default ':canary:ptb')
-  -d, --discord=DIRECTORY        Use specified Discord directory
+  -d, --discord=DIRECTORY        Use the specified Discord directory
                                  (requires --modules)
-  -m, --modules=DIRECTORY        Use specified Discord modules directory
-  -r, --bd-repo=REPOSITORY       Use specified Git repo for BetterDiscord
-      --bd-repo-branch=BRANCH    Use specified Git branch for BetterDiscord
+  -m, --modules=DIRECTORY        Use the specified Discord modules directory
+  -r, --bd-repo=REPOSITORY       Use the specified Git repo for BetterDiscord
+      --bd-repo-branch=BRANCH    Use the specified Git branch for BetterDiscord
                                  (default 'stable16')
-  -b, --betterdiscord=DIRECTORY  Use specified BetterDiscord directory
+  -b, --betterdiscord=DIRECTORY  Use the specified BetterDiscord directory
   -c, --copy-bd                  Copy BD directory instead of symlinking
       --snap[=COMMAND]           Use the Snap version of Discord (optionally
-                                 using the specified snap(1) command)
+                                 using the specified snap command)
       --flatpak[=COMMAND]        Use the Flatpak version of Discord (optionally
-                                 using the specified flatpak(1) command)
+                                 using the specified flatpak command)
+      --bdctl-url=URL            Use the specified URL for upgrading BDCTL
+                                 (default 'https://git.io/bdctl')
 
 Commands:
   status (default)               Show the current Discord patch state.
@@ -203,6 +205,16 @@ while :; do
     --flatpak=)
       die_non_empty '--flatpak'
       ;;
+    --bdctl-url)
+      if [[ ${2+x} ]]; then bdctl_url=$2; shift
+      else die_non_empty '--bdctl-url'; fi
+      ;;
+    --bdctl-url=?*)
+      bdctl_url=${1#*=}
+      ;;
+    --bdctl-url=)
+      die_non_empty '--bdctl-url'
+      ;;
     --)
       shift
       break
@@ -322,17 +334,18 @@ bdc_upgrade() {
         'If you installed this from a package, its maintainer should keep it up to date.'
   fi
 
-  github_version=$(curl -sN "$GITHUB_URL" | sed -n 's/^VERSION=//p')
+  github_version=$(curl -NLSs "$bdctl_url" | sed -n 's/^VERSION=//p')
   if [[ ${PIPESTATUS[0]} -ne 0 ]]; then
     die "ERROR: GitHub couldn't be reached to check the version."
   fi
   verbose 2 "VV: Script location: $SOURCE"
+  verbose 2 "VV: Upgrade URL: $bdctl_url"
   verbose 1 "V: Local version: $VERSION"
   verbose 1 "V: GitHub version: $github_version"
   semver_diff=$(Semver::compare "$github_version" "$VERSION")
   if [[ $semver_diff -eq 1 ]]; then
     printf 'Downloading betterdiscordctl...\n' >&2
-    if curl -Sso "$SOURCE" "$GITHUB_URL"; then
+    if curl -LSso "$SOURCE" "$bdctl_url"; then
       printf 'Successfully updated betterdiscordctl.\n' >&2
     else
       die 'ERROR: Failed to update betterdiscordctl.' \
@@ -384,8 +397,7 @@ bdc_scan() {
           fi
           if [[ -z $modules ]]; then
             bdc_find_modules
-          else
-            # --modules
+          else # --modules
             [[ -d $modules ]] || die 'ERROR: Discord modules directory not found.'
           fi
           break 3
@@ -397,7 +409,7 @@ bdc_scan() {
 
 bdc_find_modules() {
   declare -a all_modules
-  all_modules=("$discord_config/"+([0-9]).+([0-9]).+([0-9])'/modules')
+  all_modules=("$discord_config/"+([0-9]).+([0-9]).+([0-9])/modules)
   ((${#all_modules[@]})) || die 'ERROR: Discord modules directory not found.'
   modules=${all_modules[-1]}
   verbose 1 "V: Found modules in $modules"
@@ -406,14 +418,14 @@ bdc_find_modules() {
 bdc_snap() {
   # shellcheck disable=SC2016
   # Expansion should happen inside snap's shell.
-  snap_location=$("$snap_bin" run --shell discord <<< 'echo "$SNAP" 1>&3' 3>&1)
+  snap_location=$("$snap_bin" run --shell discord <<< 'echo $SNAP 1>&3' 3>&1)
   discord=${snap_location:?}/usr/share/discord
   verbose 2 "VV: Checking $discord"
   if [[ -d $discord ]]; then
     verbose 1 "V: Using Discord at $discord"
     # shellcheck disable=SC2016
     # Expansion should happen inside snap's shell.
-    xdg_config=$("$snap_bin" run --shell discord <<< 'echo "${XDG_CONFIG_HOME:-$SNAP_USER_DATA/.config}" 1>&3' 3>&1)
+    xdg_config=$("$snap_bin" run --shell discord <<< 'echo $SNAP_USER_DATA/.config 1>&3' 3>&1)
     discord_config=$xdg_config/discord
     bdc_find_modules
   else
@@ -433,14 +445,17 @@ bdc_flatpak() {
   # We're just going to grab the last line and hope for the best.
   flatpak_location=$("$flatpak_bin" info --show-location com.discordapp.Discord)
   flatpak_location=${flatpak_location##*$'\n'}
-  discord=${flatpak_location:?}/files/extra
+  if [[ -d ${flatpak_location:?}/files/discord ]]; then
+    discord=$flatpak_location/files/discord
+  else
+    discord=$flatpak_location/files/extra
+  fi
   verbose 2 "VV: Checking $discord"
   if [[ -d $discord ]]; then
     verbose 1 "V: Using Discord at $discord"
-    # We can avoid the earlier warning problem by using FD 3. yay.
     # shellcheck disable=SC2016
     # Expansion should happen inside flatpak's shell.
-    flatpak_config=$("$flatpak_bin" run --command=sh com.discordapp.Discord -c 'echo $XDG_CONFIG_HOME 1>&3' 3>&1)
+    flatpak_config=$("$flatpak_bin" run --command=sh com.discordapp.Discord -c 'echo $XDG_CONFIG_HOME')
     discord_config=${flatpak_config:-$HOME/.var/app/com.discordapp.Discord/config}/discord
     if [[ ! -d $discord_config ]]; then
       printf 'WARN: Config directory not found for Discord (%s, %s).\n' "$discord" "$discord_config" >&2

--- a/betterdiscordctl
+++ b/betterdiscordctl
@@ -11,7 +11,7 @@ DISABLE_UPGRADE=
 # Options
 cmd=status
 verbosity=0
-scan=(/opt /usr/share)
+scan=(/opt /usr/share /usr/lib64)
 flavors=('' canary ptb)
 discord=
 modules=
@@ -21,7 +21,7 @@ bd=
 copy_bd=
 snap=
 flatpak=
-bdctl_url='https://git.io/bdctl'
+upgrade_url='https://git.io/bdctl'
 
 # Variables
 flavor=
@@ -56,7 +56,7 @@ Options:
                                  using the specified snap command)
       --flatpak[=COMMAND]        Use the Flatpak version of Discord (optionally
                                  using the specified flatpak command)
-      --bdctl-url=URL            Use the specified URL for upgrading BDCTL
+      --upgrade-url=URL          URL to upgrade betterdiscordctl with
                                  (default 'https://git.io/bdctl')
 
 Commands:
@@ -205,15 +205,15 @@ while :; do
     --flatpak=)
       die_non_empty '--flatpak'
       ;;
-    --bdctl-url)
-      if [[ ${2+x} ]]; then bdctl_url=$2; shift
-      else die_non_empty '--bdctl-url'; fi
+    --upgrade-url)
+      if [[ ${2+x} ]]; then upgrade_url=$2; shift
+      else die_non_empty '--upgrade-url'; fi
       ;;
-    --bdctl-url=?*)
-      bdctl_url=${1#*=}
+    --upgrade-url=?*)
+      upgrade_url=${1#*=}
       ;;
-    --bdctl-url=)
-      die_non_empty '--bdctl-url'
+    --upgrade-url=)
+      die_non_empty '--upgrade-url'
       ;;
     --)
       shift
@@ -334,18 +334,18 @@ bdc_upgrade() {
         'If you installed this from a package, its maintainer should keep it up to date.'
   fi
 
-  github_version=$(curl -NLSs "$bdctl_url" | sed -n 's/^VERSION=//p')
+  github_version=$(curl -NLSs "$upgrade_url" | sed -n 's/^VERSION=//p')
   if [[ ${PIPESTATUS[0]} -ne 0 ]]; then
     die "ERROR: GitHub couldn't be reached to check the version."
   fi
   verbose 2 "VV: Script location: $SOURCE"
-  verbose 2 "VV: Upgrade URL: $bdctl_url"
+  verbose 2 "VV: Upgrade URL: $upgrade_url"
   verbose 1 "V: Local version: $VERSION"
   verbose 1 "V: GitHub version: $github_version"
   semver_diff=$(Semver::compare "$github_version" "$VERSION")
   if [[ $semver_diff -eq 1 ]]; then
     printf 'Downloading betterdiscordctl...\n' >&2
-    if curl -LSso "$SOURCE" "$bdctl_url"; then
+    if curl -LSso "$SOURCE" "$upgrade_url"; then
       printf 'Successfully updated betterdiscordctl.\n' >&2
     else
       die 'ERROR: Failed to update betterdiscordctl.' \
@@ -397,7 +397,8 @@ bdc_scan() {
           fi
           if [[ -z $modules ]]; then
             bdc_find_modules
-          else # --modules
+          else
+            # --modules
             [[ -d $modules ]] || die 'ERROR: Discord modules directory not found.'
           fi
           break 3
@@ -418,14 +419,14 @@ bdc_find_modules() {
 bdc_snap() {
   # shellcheck disable=SC2016
   # Expansion should happen inside snap's shell.
-  snap_location=$("$snap_bin" run --shell discord <<< 'echo $SNAP 1>&3' 3>&1)
+  snap_location=$("$snap_bin" run --shell discord <<< $'printf -- \'%s\n\' "$SNAP" 1>&3' 3>&1)
   discord=${snap_location:?}/usr/share/discord
   verbose 2 "VV: Checking $discord"
   if [[ -d $discord ]]; then
     verbose 1 "V: Using Discord at $discord"
     # shellcheck disable=SC2016
     # Expansion should happen inside snap's shell.
-    xdg_config=$("$snap_bin" run --shell discord <<< 'echo $SNAP_USER_DATA/.config 1>&3' 3>&1)
+    xdg_config=$("$snap_bin" run --shell discord <<< $'printf -- \'%s/.config\n\' "$SNAP_USER_DATA" 1>&3' 3>&1)
     discord_config=$xdg_config/discord
     bdc_find_modules
   else
@@ -455,7 +456,7 @@ bdc_flatpak() {
     verbose 1 "V: Using Discord at $discord"
     # shellcheck disable=SC2016
     # Expansion should happen inside flatpak's shell.
-    flatpak_config=$("$flatpak_bin" run --command=sh com.discordapp.Discord -c 'echo $XDG_CONFIG_HOME')
+    flatpak_config=$("$flatpak_bin" run --command=sh com.discordapp.Discord -c $'printf -- \'%s\n\' "$XDG_CONFIG_HOME"')
     discord_config=${flatpak_config:-$HOME/.var/app/com.discordapp.Discord/config}/discord
     if [[ ! -d $discord_config ]]; then
       printf 'WARN: Config directory not found for Discord (%s, %s).\n' "$discord" "$discord_config" >&2


### PR DESCRIPTION
This option allows users to specify the URL used when upgrading `betterdiscordctl`.
It can be used to apply temporary or pre-release fixes. Example:
```sh
betterdiscordctl upgrade --bdctl-url \
  'https://raw.githubusercontent.com/bb010g/betterdiscordctl/temp-fix/betterdiscordctl'
```

I've also updated the path of the flatpak version (see https://github.com/bb010g/betterdiscordctl/issues/45#issuecomment-550461177)
and removed the redirection to FD 3 because it fails with `sh: 3: Bad file descriptor`.

Moreover, it doesn't seem like snap actually uses `XDG_CONFIG_HOME` so I've removed that.

@bb010g I believe these changes require a review.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bb010g/betterdiscordctl/56)
<!-- Reviewable:end -->
