### PR TITLE
Rewrite for new BetterDiscord beta

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,19 +91,28 @@ You can then keep `betterdiscordctl` up to date with one command:
 * `--snap`
 
   Automatically detect the default Snap directories for Discord. The `-c` flag
-  is set due to Snaps apps being [confined][snapcraft-docs]. A given option
-  argument will be used as the snap command to call.
+  is set due to Snaps apps being [confined][snapcraft-docs].
+
+* `--snap-bin` (default `snap`)
+
+  Calls this `snap` executable.
 
 * `--flatpak`
 
   Automatically detect the default Flatpak directories for Discord. The `-c`
-  flag is set due to Flatpak apps being [sandboxed][flatpak-docs]. A given
-  option argument will be used as the flatpak command to call.
+  flag is set due to Flatpak apps being [sandboxed][flatpak-docs].
+
+* `--flatpak-bin` (default `flatpak`)
+
+  Calls this `flatpak` executable.
 
 * `--nix`
 
-  Automatically detect the default Nix store directories for Discord. A given
-  option argument will be used as the nix-store command to call.
+  Automatically detect the default Nix store directories for Discord.
+
+* `--nix-store-bin` (default `nix-store`)
+
+  Calls this `nix-store` executable.
 
 * `--upgrade-url` (default `https://git.io/bdctl`)
 

--- a/README.md
+++ b/README.md
@@ -13,12 +13,13 @@ A manager for BetterDiscord on Linux.
 
 ### Manual
 
-Requires `git` which you can install from your distro's [package manager][git-packages].
+Requires `curl`, which you can install from your distro's
+[package manager][curl-packages], if it's not already installed.
 
-[git-packages]:  https://git-scm.com/download/linux/
+[curl-packages]: https://curl.se/download.html#Linux
 
-You can then install as follows (`#` means that a command needs root, which you
-can get by prefixing it with `sudo`):
+You can then install as follows (`#` means that a command needs root, which
+you can get by prefixing it with `sudo`):
 
 ```
 $ curl -O https://raw.githubusercontent.com/bb010g/betterdiscordctl/master/betterdiscordctl
@@ -46,12 +47,6 @@ You can then keep `betterdiscordctl` up to date with one command:
 
   Increases the verbosity level, for progressively more debugging information.
 
-* `-s` / `--scan` (default `/opt:/usr/share:/usr/lib64`)
-
-  Changes the directories scanned for Discord installations. These are scanned
-  in the order provided. Note that these do **not** end in `/discord`—if your
-  Discord installation is at `/opt/discord`, then `/opt` should be scanned.
-
 * `-f` / `--flavors` (default `:canary:ptb`)
 
   When scanning, looks for installations with the given suffixes (case
@@ -59,67 +54,45 @@ You can then keep `betterdiscordctl` up to date with one command:
   suffix. Note that **no** spaces follow colons. Your Discord flavor probably
   doesn't have a space in it, so don't use any in here.
 
-* `-d` / `--discord` (requires `--modules`)
-
-  Skip scanning and use the Discord installation directory specified. This
-  **does** probably end in `/discord`.
-
 * `-m` / `--modules`
 
   Disregards scanning results and uses the specified modules directory (found
   inside Discord's user-specific storage directory).
 
-* `-r` / `--bd-repo` (default `https://github.com/rauenzi/BetterDiscordApp`)
+* `-r` / `--bd-repo` (default `rauenzi/BetterDiscordApp`)
 
-  When installing BetterDiscord, use the specified Git repository. Does _not_
-  affect updates. Defaults to Zerebos's BandagedBD fork.
+  When installing BetterDiscord, use the specified GitHub repository.
+  Defaults to upstream BetterDiscord.
 
-* `--bd-repo-branch` (default `injector`)
+* `-R` / `--bd-release` (default `latest`)
 
-  When downloading from `--bd-repo`, use this branch.
+  When downloading from `--bd-repo`, use this release.
 
-* `-b` / `--betterdiscord`
+* `-a` / `--bd-asar`
 
-  Instead of maintaining a local clone of BetterDiscord, use the specified
-  directory.
-
-* `-c` / `--copy-bd`
-
-  Instead of using a symbolic link, copy the BetterDiscord directory into
-  Discord's modules.
-
-* `--snap`
-
-  Automatically detect the default Snap directories for Discord. The `-c` flag
-  is set due to Snaps apps being [confined][snapcraft-docs].
-
-* `--snap-bin` (default `snap`)
-
-  Calls this `snap` executable.
+  Instead of downloading `betterdiscord.asar` from a release, use the
+  specified BetterDiscord asar file. This flag is mostly meant for
+  **developers** testing custom BetterDiscord builds.
 
 * `--flatpak`
 
-  Automatically detect the default Flatpak directories for Discord. The `-c`
-  flag is set due to Flatpak apps being [sandboxed][flatpak-docs].
+  Automatically detect the default Flatpak directory for Discord.
 
 * `--flatpak-bin` (default `flatpak`)
 
   Calls this `flatpak` executable.
 
-* `--nix`
+* `--snap`
 
-  Automatically detect the default Nix store directories for Discord.
+  Automatically detect the default Snap directory for Discord.
 
-* `--nix-store-bin` (default `nix-store`)
+* `--snap-bin` (default `snap`)
 
-  Calls this `nix-store` executable.
+  Calls this `snap` executable.
 
-* `--upgrade-url` (default `https://git.io/bdctl`)
+* `--upgrade-url` (default `https://github.com/bb010g/betterdiscordctl/raw/master/betterdiscordctl`)
 
   Use the specified URL for upgrading betterdiscordctl.
-
-[snapcraft-docs]: https://docs.snapcraft.io/reference/confinement
-[flatpak-docs]:   http://docs.flatpak.org/en/latest/working-with-the-sandbox.html
 
 ## Commands
 
@@ -135,14 +108,6 @@ Installs BetterDiscord, managing what's necessary by default.
 
 Reinstalls BetterDiscord, removing the old files.
 
-### `update`
-
-Updates BetterDiscord, updating your local repository if present
-(`origin` branch). Also cleans up any old patch methods, if found.
-
-(Advanced users should avoid using this if locally modifying their
-linked repositories, and should instead manually fetch and update.)
-
 ### `uninstall`
 
 Uninstalls BetterDiscord, removing the managed repository if used.
@@ -157,46 +122,34 @@ Updates `betterdiscordctl` to the latest version available on GitHub.
 
   Works like `betterdiscordctl status`.
 
-* `betterdiscordctl status -s /usr/share`
+* `betterdiscordctl status -f ptb`
 
-  Shows the status of the default Discord installation in `/usr/share`,
-  instead of `/opt`.
+  Shows the BetterDiscord for the PTB flavor.
 
-* `betterdiscordctl install -f ptb`
+* `betterdiscordctl install -f canary`
 
-  Installs BetterDiscord to the PTB flavor, instead of the default.
+  Installs BetterDiscord to the Canary flavor.
 
-* `betterdiscordctl reinstall -f canary`
+* `betterdiscordctl reinstall --flatpak`
 
-  Reinstalls BetterDiscord to Discord Canary.
-
-* `betterdiscordctl update --flatpak`
-
-  Updates BetterDiscord for a Discord installed via Flatpak.
+  Reinstalls BetterDiscord to a Discord installed via Flatpak.
 
 * `betterdiscordctl uninstall --snap`
 
-  Uninstalls BetterDiscord for a Discord installed via Snap.
+  Uninstalls BetterDiscord from a Discord installed via Snap.
 
 ## Files
 
 * `$XDG_DATA_HOME/betterdiscordctl` (fallback `~/.local/share/betterdiscordctl`)
 
-  `betterdiscordctl`'s machine-specific data directory.
-
-* `$XDG_DATA_HOME/betterdiscordctl/bd_map`
-
-  A mapping of current Discord installations to BetterDiscord clones.
-
-* `$XDG_DATA_HOME/betterdiscordctl/bd`
-
-  A directory of BetterDiscord clones, indexed by `bd_map`.
+  `betterdiscordctl`'s machine-specific data directory. Currently unused and
+  not created on new installs.
 
 * `$XDG_CONFIG_HOME/BetterDiscord` (fallback `~/.config/BetterDiscord`)
 
   `betterdiscord`'s normal data & configuration.
 
-  * With `--snap`, this will fall back to `$SNAP_USER_DATA/.config`.
-
   * With `--flatpak`, this will fall back to
     `~/.var/app/com.discordapp.Discord/config/BetterDiscord`.
+
+  * With `--snap`, this will fall back to `$SNAP_USER_DATA/.config`.

--- a/README.md
+++ b/README.md
@@ -30,77 +30,107 @@ $ chmod +x betterdiscordctl
 You can then keep `betterdiscordctl` up to date with one command:
 
 ```
-# betterdiscordctl upgrade
+# betterdiscordctl self-upgrade
 ```
 
 ## Options
 
-* `-V` / `--version`
+betterdiscordctl (mostly) follows the Fuchsia
+[command-line tools rubric's execution section][fuchsia-cli-execution] and
+[CLI tool help requirements][fuchsia-cli_help].
+
+[fuchsia-cli-execution]: https://fuchsia.dev/fuchsia-src/concepts/api/cli#execution
+[fuchsia-cli_help]: https://fuchsia.dev/fuchsia-src/concepts/api/cli_help
+
+* `-V`, `--version`
 
   Displays the current version.
 
-* `-h` / `--help`
+* `-h`, `--help`
 
   Displays usage information.
 
-* `-v` / `--verbose`
+* `-v`, `--verbose`
 
   Increases the verbosity level, for progressively more debugging information.
 
-* `-q` / `--quiet`
+* `-q`, `--quiet`
 
   Decreases the verbosity level, for progressively less debugging information.
 
-* `-f` / `--flavors` (default `:canary:ptb`)
+* `-f`, `--d-flavors` `<d_flavors>` (default `:canary:ptb`)
 
   When scanning, looks for installations with the given suffixes (case
   insensitive, both hyphenated and unhyphenated). Stable is `''`, as it has no
   suffix. Note that **no** spaces follow colons. Your Discord flavor probably
   doesn't have a space in it, so don't use any in here.
 
-* `-m` / `--modules`
+  Flavors besides `''` are only relevant to traditional Discord installations.
+
+* `-m`, `--d-modules` `<d_modules>`
 
   Disregards scanning results and uses the specified modules directory (found
   inside Discord's user-specific storage directory).
 
-* `-r` / `--bd-repo` (default `rauenzi/BetterDiscordApp`)
+* `-D`, `--bd-remote-dir` `<bd_r_dir>`
 
-  When installing BetterDiscord, use the specified GitHub repository.
-  Defaults to upstream BetterDiscord.
+  When installing BetterDiscord, use the specified local directory. Overrides
+  earlier `--bd-remote-url` or `--bd-remote-github`. `''` keeps a previous
+  value.
 
-* `-R` / `--bd-release` (default `latest`)
+* `-U`, `--bd-remote-url` `<bd_r_url>`
 
-  When downloading from `--bd-repo`, use this release.
+  When installing BetterDiscord, use the specified base URL. Overrides earlier
+  `--bd-remote-dir` or `--bd-remote-github`. `''` keeps a previous value.
 
-* `-a` / `--bd-asar`
+  Works like `--bd-remote-dir` with files downloaded into BetterDiscord's data
+  directory.
+
+* `-H`, `--bd-remote-github` `<bd_r_github>` (default `~rauenzi/BetterDiscordApp#latest`)
+
+  When installing BetterDiscord, use the specified GitHub repository, of form
+  `[~<owner>][/<repo>][#<release>]`. Defaults to upstream BetterDiscord.
+  Overrides earlier `--bd-remote-dir` or `--bd-remote-url`. Omitted parts keep
+  previous values (e.g. `-H '~rauenzi'` only changes the owner to `rauenzi`,
+  and `-H ''` changes nothing but still ensures the configured GitHub
+  repository will be used).
+
+  Works like `--bd-remote-url` with a GitHub repository release download base
+  URL.
+
+* `--bd-remote-asar` `<bd_r_asar>`
 
   Instead of downloading `betterdiscord.asar` from a release, use the
-  specified BetterDiscord asar file. This flag is mostly meant for
-  **developers** testing custom BetterDiscord builds.
+  specified BetterDiscord asar file name. This flag is mostly meant for quirky
+  tests of custom BetterDiscord builds.
 
-* `--flatpak`
+* `-i`, `--d-install` …
+
+  + `traditional` (default)
+
+  + `flatpak`
 
   Automatically detect the default Flatpak directory for Discord.
 
-* `--flatpak-bin` (default `flatpak`)
-
-  Calls this `flatpak` executable.
-
-* `--snap`
+  + `snap`
 
   Automatically detect the default Snap directory for Discord.
 
-* `--snap-bin` (default `snap`)
+* `--flatpak-bin` `<flatpak>` (default `flatpak`)
+
+  Calls this `flatpak` executable.
+
+* `--snap-bin` `<snap>` (default `snap`)
 
   Calls this `snap` executable.
 
-* `--upgrade-url` (default `https://github.com/bb010g/betterdiscordctl/raw/master/betterdiscordctl`)
+* `--upgrade-url` `<upgrade_url>` (default `https://github.com/bb010g/betterdiscordctl/raw/master/betterdiscordctl`)
 
-  Use the specified URL for upgrading betterdiscordctl.
+  Use the specified URL for self-upgrading betterdiscordctl.
 
 ## Commands
 
-### `status` (default)
+### `status`
 
 Displays information about your current BetterDiscord setup.
 
@@ -116,29 +146,32 @@ Reinstalls BetterDiscord, removing the old files.
 
 Uninstalls BetterDiscord, removing the managed repository if used.
 
-### `upgrade`
+### `self-upgrade`
 
-Updates `betterdiscordctl` to the latest version available on GitHub.
+Upgrades `betterdiscordctl` to the latest version available on GitHub.
+
+If `betterdiscordctl` is installed from a package, self-upgrading may be
+disabled, in which case the package's maintainer should keep it up to date.
 
 ## Examples
 
-* `betterdiscordctl`
+* `betterdiscordctl --help`
 
-  Works like `betterdiscordctl status`.
+  Lists options & commands.
 
-* `betterdiscordctl status -f ptb`
+* `betterdiscordctl -f ptb status`
 
-  Shows the BetterDiscord for the PTB flavor.
+  Shows the BetterDiscord status for the PTB flavor.
 
-* `betterdiscordctl install -f canary`
+* `betterdiscordctl -f canary install`
 
   Installs BetterDiscord to the Canary flavor.
 
-* `betterdiscordctl reinstall --flatpak`
+* `betterdiscordctl -i flatpak reinstall`
 
   Reinstalls BetterDiscord to a Discord installed via Flatpak.
 
-* `betterdiscordctl uninstall --snap`
+* `betterdiscordctl -i snap uninstall`
 
   Uninstalls BetterDiscord from a Discord installed via Snap.
 

--- a/README.md
+++ b/README.md
@@ -47,6 +47,10 @@ You can then keep `betterdiscordctl` up to date with one command:
 
   Increases the verbosity level, for progressively more debugging information.
 
+* `-q` / `--quiet`
+
+  Decreases the verbosity level, for progressively less debugging information.
+
 * `-f` / `--flavors` (default `:canary:ptb`)
 
   When scanning, looks for installations with the given suffixes (case

--- a/betterdiscordctl
+++ b/betterdiscordctl
@@ -6,78 +6,115 @@ shopt -s dotglob extglob nullglob
 # Constants
 VERSION=2.0.0
 SOURCE=$(readlink -f "${BASH_SOURCE[0]}")
-DISABLE_UPGRADE=
+DISABLE_SELF_UPGRADE=
 
 # Options
-cmd=status
+cmd=
 verbosity=0
 d_flavors=('' canary ptb)
 d_modules=
-bd_repo='rauenzi/BetterDiscordApp'
-bd_release=latest
-bd_asar=
-flatpak=
+bd_remote=github
+bd_remote_dir=
+bd_remote_url=
+bd_remote_github_owner=rauenzi
+bd_remote_github_repo=BetterDiscordApp
+bd_remote_github_release=latest
+bd_remote_asar=betterdiscord.asar
+d_install=traditional
 flatpak_bin=flatpak
-snap=
 snap_bin=snap
-upgrade_url='https://github.com/bb010g/betterdiscordctl/raw/master/betterdiscordctl'
+self_upgrade_url='https://github.com/bb010g/betterdiscordctl/raw/master/betterdiscordctl'
 
 # Variables
 d_flavor=
 d_core=
-xdg_config=${XDG_CONFIG_HOME:-$HOME/.config}
+xdg_config=
 bdc_data=${XDG_DATA_HOME:-$HOME/.local/share}/betterdiscordctl
 d_config=
-bd_config=$xdg_config/BetterDiscord
-bd_asar_dest=$bd_config/data/betterdiscord.asar
+bd_config=
+bd_asar=
+bd_asar_escaped=
+bd_asar_name=
 
 show_help() {
   cat << EOF
-Usage: ${0##*/} [COMMAND] [OPTION...]
+Usage: ${0##*/} [-f d_flavors] \\
+  [-D <bd_r_dir>|-U <bd_r_url>|-H <bd_r_github>] \\
+  [-i (traditional|flatpak|snap)] <command>
+
+Manage BetterDiscord installations on Linux.
 
 Options:
-  -V, --version                  Display version info and exit
-  -h, --help                     Display this help message and exit
-  -v, --verbose                  Increase verbosity
-  -q, --quiet                    Decrease verbosity
-  -f, --flavors=FLAVORS          Colon-separated list of Discord flavors
-                                 (default: ":canary:ptb")
-  -m, --modules=DIRECTORY        Use the specified Discord modules directory
-  -r, --bd-repo=REPOSITORY       Use the specified git repo for BetterDiscord
-  -R, --bd-release=RELEASE       Use the specified release for BetterDiscord
-  -a, --bd-asar=FILE             Use the specified betterdiscord.asar file
-      --flatpak                  Use the Flatpak version of Discord
-      --flatpak-bin=EXECUTABLE   Use the specified "flatpak" executable
-      --snap                     Use the Snap version of Discord
-      --snap-bin=EXECUTABLE      Use the specified "snap" executable
-      --upgrade-url=URL          Custom URL to upgrade betterdiscordctl with
+  -V, --version                 display version info and exit
+  -h, --help                    display this help message and exit
+  -v, --verbose                 increase verbosity
+  -q, --quiet                   decrease verbosity
+  -f, --d-flavors <d_flavors>   discover Discord installations with the
+                                colon-separated list of suffixes <d_flavors>.
+                                Defaults to ':canary:ptb'. Flavors must be
+                                lowercase. Stable is flavor '', as it's
+                                unsuffixed. Flavors shouldn't include spaces.
+  -m, --d-modules <d_modules>   use Discord modules in directory <d_modules>.
+                                Defaults to discovery. Discord's user-specific
+                                storage directory should contain <d_modules>.
+  -D, --bd-remote-dir           reference BetterDiscord files at directory
+    <bd_r_dir>                  <bd_r_dir>. Overrides earlier --bd-remote-url
+                                or --bd-remote-github. An empty string keeps a
+                                previous value.
+  -U, --bd-remote-url           download BetterDiscord files at base URL
+    <bd_r_url>                  <bd_r_url>. Overrides earlier --bd-remote-dir
+                                or --bd-remote-github. An empty string keeps a
+                                previous value. Works like --bd-remote-dir
+                                with files downloaded into BetterDiscord's
+                                data directory.
+  -H, --bd-remote-github        download BetterDiscord files at GitHub
+    <bd_r_github>               repository release <bd_r_github>, of form
+                                [~<owner>][/<repo>][#<release>]. Defaults to
+                                '~rauenzi/BetterDiscordApp#latest'. Overrides
+                                earlier --bd-remote-dir or --bd-remote-github.
+                                An omitted part keeps a previous value.
+                                <owner> and <repo> must not contain '~', '/',
+                                or '#'. Works like --bd-remote-url with a
+                                GitHub repository release download base URL.
+  --bd-remote-asar <bd_r_asar>  finds "betterdiscord.asar" at path <bd_r_asar>
+                                relative to remote. Defaults to
+                                'betterdiscord.asar'.
+  -i, --d-install traditional   use a traditional Discord install. Default.
+  -i, --d-install flatpak       use a Discord Flatpak app
+  -i, --d-install snap          use a Discord Snap app
+  --flatpak-bin <flatpak>       invoke Flatpak executable <flatpak>. Defaults
+                                to 'flatpak'.
+  --snap-bin <snap>             invoke Snap executable <snap>. Defaults to
+                                'snap'.
+  --self-upgrade-url            query <self_upgrade_url> for self-upgrades
+    <self_upgrade_url>
 
 Commands:
-  status (default)               Show the current Discord patch state.
-  install                        Install BetterDiscord.
-  reinstall                      Reinstall BetterDiscord.
-  uninstall                      Uninstall BetterDiscord.
-  upgrade                        Update betterdiscordctl.
+  status                        show the current Discord patch state
+  install                       install BetterDiscord
+  reinstall                     reinstall BetterDiscord
+  uninstall                     uninstall BetterDiscord
+  self-upgrade                  upgrade this program
 EOF
 }
 
 verbose() {
   if (( verbosity >= $1 )); then
     shift
-    printf '%s\n' "$1" >&2
+    >&2 printf '%s\n' "$1"
   fi
 }
 
 die() {
   while (( $# > 0 )); do
-    printf '%s\n' "$1" >&2
+    >&2 printf '%s\n' "$1"
     shift
   done
   exit 1
 }
 
 die_with_help() {
-  die "$@" 'Use "--help" for more information.'
+  die "$@" "Use \`${0##*/} --help\` for more information."
 }
 
 die_option() {
@@ -88,57 +125,91 @@ die_non_empty_option() {
   die_with_help "ERROR: \"$1\" requires a non-empty option argument."
 }
 
+die_non_empty_option_part() {
+  die_with_help "ERROR: \"$1\" requires a non-empty $2 option argument part."
+}
+
+# arg parsing: top-level: options
 while :; do
   if [[ -z ${1+x} ]]; then break; fi
   case $1 in
-    status|install|reinstall|uninstall|upgrade)
-      cmd=$1
-      ;;
     -V|--version)
-      printf 'betterdiscordctl %s\n' "$VERSION" >&2
+      >&2 printf 'betterdiscordctl %s\n' "$VERSION"
       exit
       ;;
     -h|-\?|--help)
       show_help; exit
       ;;
     -v|--verbose)
-      ((verbosity++))
+      ((verbosity++)) || :
       ;;
     -q|--quiet)
-      ((verbosity--))
+      ((verbosity--)) || :
       ;;
-    -f|--flavors)
-      if [[ ${2+x} ]]; then IFS=':' read -ra d_flavors <<< "$2:"; shift
+    -f|--d-flavors)
+      if [[ ${2+x} ]]; then
+        if [[ $2 != "${2,,}" ]]; then
+          die_with_help "ERROR: Discord flavors list must be lowercase: $2"
+        else
+          IFS=':' read -ra d_flavors <<< "$2:"; shift
+        fi
       else die_option "$1"; fi
       ;;
-    -m|--modules)
+    -m|--d-modules)
       if [[ ${2:+x} ]]; then d_modules=$2; shift
       else die_non_empty_option "$1"; fi
       ;;
-    -r|--bd-repo)
-      if [[ ${2:+x} ]]; then bd_repo=$2; shift
+    -D|--bd-remote-dir)
+      bd_remote=dir
+      if [[ ${2+x} ]]; then [[ ${2:+x} ]] && bd_remote_dir=$2; shift
+      else die_option "$1"; fi
+      ;;
+    -U|--bd-remote-url)
+      bd_remote=url
+      if [[ ${2+x} ]]; then [[ ${2:+x} ]] && bd_remote_url=$2; shift
+      else die_option "$1"; fi
+      ;;
+    -H|--bd-remote-github)
+      bd_remote=github
+      if [[ ${2+x} ]]; then
+        if [[ ! $2 =~ (~?[^~/#]*)(/?[^~/#]*)(#?.*) ]]; then
+          die_with_help "ERROR: \"$1\" requires a valid option argument."
+        fi
+        if [[ ${BASH_REMATCH[1]} ]]; then
+          [[ ${BASH_REMATCH[2]} != '~' ]] || die_non_empty_option_part "$1" '<owner>'
+          bd_remote_github_owner=${BASH_REMATCH[1]:1}
+        fi
+        if [[ ${BASH_REMATCH[2]} ]]; then
+          [[ ${BASH_REMATCH[2]} != '/' ]] || die_non_empty_option_part "$1" '<repo>'
+          bd_remote_github_repo=${BASH_REMATCH[2]:1}
+        fi
+        if [[ ${BASH_REMATCH[3]} ]]; then
+          [[ ${BASH_REMATCH[3]} != '#' ]] || die_non_empty_option_part "$1" '<release>'
+          bd_remote_github_release=${BASH_REMATCH[3]:1}
+        fi
+        shift
+      else die_option "$1"; fi
+      ;;
+    --bd-remote-asar)
+      if [[ ${2:+x} ]]; then bd_remote_asar=$2; shift
       else die_non_empty_option "$1"; fi
       ;;
-    -R|--bd-release)
-      if [[ ${2:+x} ]]; then bd_release=$2; shift
-      else die_non_empty_option "$1"; fi
+    --d-install)
+      if [[ ${2:+x} ]]; then case "$2" in
+        traditional|flatpak|snap) d_install=$2 ;;
+        *) die_with_help "ERROR: Unknown top-level $1 value: $2" ;;
+      esac; shift; else die_non_empty_option "$1"; fi
       ;;
-    -a|--bd-asar)
-      if [[ ${2:+x} ]]; then bd_asar=$2; shift
-      else die_non_empty_option "$1"; fi
-      ;;
-    --flatpak) flatpak=yes ;;
     --flatpak-bin)
       if [[ ${2:+x} ]]; then flatpak_bin=$2; shift
       else die_non_empty_option "$1"; fi
       ;;
-    --snap) snap=yes ;;
     --snap-bin)
       if [[ ${2:+x} ]]; then snap_bin=$2; shift
       else die_non_empty_option "$1"; fi
       ;;
-    --upgrade-url)
-      if [[ ${2:+x} ]]; then upgrade_url=$2; shift
+    --self-upgrade-url)
+      if [[ ${2:+x} ]]; then self_upgrade_url=$2; shift
       else die_non_empty_option "$1"; fi
       ;;
     # footer
@@ -150,6 +221,58 @@ while :; do
   esac
   shift
 done
+# arg parsing: top-level: arguments
+while :; do
+  if [[ -z ${1+x} ]]; then break; fi
+  case "$1" in
+    status|install|reinstall|uninstall|self-upgrade)
+      cmd=$1
+      shift
+      break
+      ;;
+    *) die_with_help "ERROR: Unknown top-level argument: $1"
+  esac
+  shift
+done
+# arg parsing: top-level: validation
+case "$bd_remote" in
+  github)
+    [[ $bd_remote_github_owner ]] || die_non_empty_option_part '--bd-remote-github' '<owner>'
+    [[ $bd_remote_github_repo ]] || die_non_empty_option_part '--bd-remote-github' '<repo>'
+    [[ $bd_remote_github_release ]] || die_non_empty_option_part '--bd-remote-github' '<release>'
+    ;;
+  url)
+    [[ $bd_remote_url ]] || die_non_empty_option '--bd-remote-url'
+    ;;
+  dir)
+    [[ $bd_remote_dir ]] || die_non_empty_option '--bd-remote-dir'
+    ;;
+esac
+# arg parsing: top-level: command dispatch
+case "$cmd" in
+  status|install|reinstall|uninstall|self-upgrade)
+    # arg parsing: (status|install|reinstall|uninstall|self-upgrade): options
+    while :; do
+      if [[ -z ${1+x} ]]; then break; fi
+        case "$1" in
+          # footer
+          -*=*) die "ERROR: Keyed options must not be separated by equals: $1" ;;
+          --) shift; break ;;
+          -?|--*) die_with_help "ERROR: Unknown |$cmd| option: $1" ;;
+          -??*) die "ERROR: Switches must not be ran together: $1" ;;
+        esac
+      shift
+    done
+    # arg parsing: (status|install|reinstall|uninstall|self-upgrade): arguments
+    if [[ -n ${1+x} ]]; then
+      die_with_help "ERROR: Unknown |$cmd| argument: $1"
+    fi
+    ;;
+  '')
+    die_with_help "ERROR: Specify a non-empty command."
+    ;;
+  *) die "ERROR: [arg parsing: top-level: command dispatch] Unknown command: $cmd" ;;
+esac
 
 # currently unused
 # mkdir -p "$bdc_data"
@@ -157,88 +280,115 @@ done
 # Commands
 
 bdc_status() {
+  declare asar_install bd_remote_status index_mod
   asar_install=no
   index_mod=no
-  verbose 2 "VV: BetterDiscord asar installation: $bd_asar_dest"
-  if [[ -h $bd_asar_dest && ! -f $bd_asar_dest ]]; then
+  verbose 2 "VV: BetterDiscord asar installation: $bd_asar"
+  if [[ -h $bd_asar && ! -f $bd_asar ]]; then
     asar_install='(broken link) no'
-  elif [[ -f $bd_asar_dest ]]; then
+  elif [[ -f $bd_asar ]]; then
     asar_install='(symbolic link) yes'
   elif [[ -d $bd_config ]]; then
     asar_install='(missing) no'
   fi
-  grep -Fq 'betterdiscord.asar' "$d_core/index.js" && index_mod=yes
+  if grep -Fq "$bd_asar_escaped" "$d_core/index.js"; then
+    index_mod=yes
+  elif grep -Fq "$bd_asar_name" "$d_core/index.js"; then
+    index_mod=noncompliant
+  elif grep -Fq 'betterdiscord.asar' "$d_core/index.js"; then
+    index_mod=noncompliant
+  fi
 
-  printf 'Discord flavor: %s
+  bd_remote_status="$bd_remote"
+  case "$bd_remote" in
+    github)
+      bd_remote_status+="
+BetterDiscord remote GitHub: ~$bd_remote_github_owner/$bd_remote_github_repo#$bd_remote_github_release"
+      ;;
+    url)
+      bd_remote_status+="
+BetterDiscord remote URL: $bd_remote_url"
+      ;;
+    dir)
+      bd_remote_status+="
+BetterDiscord remote directory: $bd_remote_dir"
+      ;;
+  esac
+
+  printf 'Discord install: %s
+Discord flavor: %s
 Discord modules: %s
 BetterDiscord directory: %s
 BetterDiscord asar installed: %s
-Index modified: %s
-' "$d_flavor" "$d_modules" "$bd_config" "$asar_install" "$index_mod"
+Discord "index.js" injected: %s
+BetterDiscord remote: %s
+' "$d_install" "$d_flavor" "$d_modules" "$bd_config" "$asar_install" \
+    "$index_mod" "$bd_remote_status"
 }
 
 bdc_install() {
-  grep -Fq 'betterdiscord.asar' "$d_core/index.js" && die 'ERROR: Already installed.'
+  grep -Fq "$bd_asar_escaped" "$d_core/index.js" && die 'ERROR: Already installed.'
   bdc_clean_legacy
 
-  bd_install_asar
-  bd_patch
+  bd_remote_install
+  bd_install
 
-  printf 'Installed. (Restart Discord if necessary.)\n' >&2
+  >&2 printf 'Installed. (Restart Discord if necessary.)\n'
 }
 
 bdc_reinstall() {
-  grep -Fq 'betterdiscord.asar' "$d_core/index.js" || die 'ERROR: Not installed.'
+  grep -Fq "$bd_asar_name" "$d_core/index.js" || die 'ERROR: Not installed.'
   bdc_clean_legacy
 
   bdc_kill
 
-  bd_install_asar
-  bd_patch
+  bd_remote_install
+  bd_install
 
-  printf 'Reinstalled.\n' >&2
+  >&2 printf 'Reinstalled.\n'
 }
 
 bdc_uninstall() {
-  grep -Fq 'betterdiscord.asar' "$d_core/index.js" || die 'ERROR: Not installed.'
+  grep -Fq "$bd_asar_name" "$d_core/index.js" || die 'ERROR: Not installed.'
   bdc_clean_legacy
 
   bdc_kill
-  bd_unpatch
+  bd_uninstall
 
-  printf 'Uninstalled.\n' >&2
+  >&2 printf 'Uninstalled.\n'
 }
 
-bdc_upgrade() {
-  if [[ $DISABLE_UPGRADE ]]; then
-    die 'ERROR: Upgrading has been disabled.' \
+bdc_self_upgrade() {
+  if [[ $DISABLE_SELF_UPGRADE ]]; then
+    die 'ERROR: Self-upgrading has been disabled.' \
         'If you installed this from a package, its maintainer should keep it up to date.'
   fi
 
-  github_version=$(curl -NLSs "$upgrade_url" | sed -n 's/^VERSION=//p')
+  declare self_upgrade_version semver_diff
+  self_upgrade_version=$(curl -NLSs "$self_upgrade_url" | sed -n 's/^VERSION=//p')
   if [[ ${PIPESTATUS[0]} -ne 0 ]]; then
-    die "ERROR: GitHub couldn't be reached to check the version."
+    die "ERROR: The remote script URL couldn't be reached to check the version."
   fi
-  verbose 2 "VV: Script location: $SOURCE"
-  verbose 2 "VV: Upgrade URL: $upgrade_url"
+  verbose 2 "VV: Local script location: $SOURCE"
+  verbose 2 "VV: Remote script URL: $self_upgrade_url"
   verbose 1 "V: Local version: $VERSION"
-  verbose 1 "V: GitHub version: $github_version"
-  semver_diff=$(Semver::compare "$github_version" "$VERSION")
+  verbose 1 "V: Remote version: $self_upgrade_version"
+  semver_diff=$(Semver::compare "$self_upgrade_version" "$VERSION")
   if [[ $semver_diff -eq 1 ]]; then
-    printf 'Downloading betterdiscordctl...\n' >&2
-    if curl -LSso "$SOURCE" "$upgrade_url"; then
-      printf 'Successfully updated betterdiscordctl.\n' >&2
+    >&2 printf 'Downloading betterdiscordctl...\n'
+    if curl -LSso "$SOURCE" "$self_upgrade_url"; then
+      >&2 printf 'Successfully self-upgraded betterdiscordctl.\n'
     else
-      die 'ERROR: Failed to update betterdiscordctl.' \
-          'You may want to rerun this command with sudo.'
+      die 'ERROR: Failed to self-upgrade betterdiscordctl.' \
+          "You may want to rerun this command with \`sudo\`."
     fi
   else
     if [[ $semver_diff -eq 0 ]]; then
-      printf 'betterdiscordctl is already the latest version (%s).\n' \
-          "$VERSION" >&2
+      >&2 printf 'betterdiscordctl is already the latest version (%s).\n' \
+          "$VERSION"
     else
-      printf 'Local version (%s) is higher than GitHub version (%s).\n' \
-          "$VERSION" "$github_version" >&2
+      >&2 printf 'Local version (%s) is higher than remote version (%s).\n' \
+          "$VERSION" "$self_upgrade_version"
     fi
   fi
 }
@@ -246,117 +396,180 @@ bdc_upgrade() {
 # Implementation functions
 
 bdc_main() {
-  if [[ -z $d_modules ]]; then
-    if [[ $flatpak ]]; then bdc_flatpak
-    elif [[ $snap ]]; then bdc_snap
-    else bdc_scan; fi
-  else
-    [[ -d $d_modules ]] || die 'ERROR: Discord modules directory not found.'
-    d_flavor=${d_modules%/*/modules}
-    d_flavor=${d_flavor##*/discord}
-  fi
-  [[ -d $d_modules ]] || die 'ERROR: Discord modules directory not found.' \
-      'Try specifying it with "--modules".'
+  xdg_discover_config
+  bdc_discover
   d_core=$d_modules/discord_desktop_core
-  [[ -d $d_core ]] || die "ERROR: Directory 'discord_desktop_core' not found in $d_modules"
+  [[ -d $d_core ]] || die "ERROR: Directory 'discord_desktop_core' not found in: $d_modules"
+  bd_remote_init
+  bd_asar=$bd_config/data/$bd_asar_name
+  bd_asar_escaped=${bd_asar/\\/\\\\}
 }
 
-bdc_scan() {
-  for d_flavor in "${d_flavors[@]}"; do
-    verbose 2 "VV: Trying flavor '$d_flavor'"
-    d_config=$xdg_config/discord${d_flavor,,}
-    if [[ ! -d $d_config ]]; then
-      printf 'WARN: Discord %s config directory not found (%s).\n' \
-          "$d_flavor" "$d_config" >&2
-      continue
-    fi
-    if [[ -z $d_modules ]]; then
-      bdc_find_modules
-    elif [[ ! -d $d_modules ]]; then
-      die 'ERROR: Discord modules directory not found.'
-    fi
-    break
-  done
+xdg_discover_config() {
+  case "$d_install" in
+    traditional)
+      xdg_config=${XDG_CONFIG_HOME:-$HOME/.config}
+      ;;
+    snap)
+      # shellcheck disable=SC2016
+      # Expansion should happen inside snap's shell.
+      xdg_config=$("$snap_bin" run --shell discord \
+          <<< $'printf -- \'%s/.config\n\' "$SNAP_USER_DATA" 1>&3' 3>&1)
+      ;;
+    flatpak)
+      # shellcheck disable=SC2016
+      # Expansion should happen inside flatpak's shell.
+      xdg_config=$("$flatpak_bin" run --command=sh com.discordapp.Discord \
+          -c $'printf -- \'%s\n\' "$XDG_CONFIG_HOME"')
+      xdg_config=${xdg_config:-$HOME/.var/app/com.discordapp.Discord/config}
+      ;;
+    *) die "ERROR: [xdg_discover_config] Unknown Discord install variant: $d_install" ;;
+  esac
+  [[ $xdg_config ]] || >&2 printf "WARN: XDG user config directory (\$XDG_CONFIG_HOME) not found.\n"
+}
+
+bdc_discover() {
+  d_discover_config
+  bd_discover_config
+  bdc_find_modules
 }
 
 bdc_find_modules() {
-  [[ -d $d_config ]] || die "ERROR: Discord $d_flavor config directory not found ($d_config)."
-  declare -a all_d_modules
-  all_d_modules=("$d_config/"+([0-9]).+([0-9]).+([0-9])/modules)
-  ((${#all_d_modules[@]})) || die 'ERROR: Discord modules directory not found.'
-  d_modules=${all_d_modules[-1]}
-  verbose 1 "V: Found modules in $d_modules"
-}
-
-bdc_snap() {
-  # shellcheck disable=SC2016
-  # Expansion should happen inside snap's shell.
-  xdg_config=$("$snap_bin" run --shell discord \
-      <<< $'printf -- \'%s/.config\n\' "$SNAP_USER_DATA" 1>&3' 3>&1)
-  d_config=$xdg_config/discord
-  bd_config=$xdg_config/BetterDiscord
-  bd_asar_dest=$bd_config/data/betterdiscord.asar
-  bdc_find_modules
-}
-
-bdc_flatpak() {
-  # shellcheck disable=SC2016
-  # Expansion should happen inside flatpak's shell.
-  xdg_config=$("$flatpak_bin" run --command=sh com.discordapp.Discord \
-      -c $'printf -- \'%s\n\' "$XDG_CONFIG_HOME"')
-  d_config=${xdg_config:-$HOME/.var/app/com.discordapp.Discord/config}/discord
-  bd_config=$xdg_config/BetterDiscord
-  bd_asar_dest=$bd_config/data/betterdiscord.asar
-  bdc_find_modules
+  if [[ $d_modules ]]; then
+    [[ -d $d_modules ]] || die "ERROR: Discord modules directory not found: $d_modules"
+    d_flavor=${d_modules%/*/modules}
+    d_flavor=${d_flavor##*/discord}
+  else
+    [[ -d $d_config ]] || die "ERROR: Discord $d_flavor config directory not found: $d_config"
+    declare -a all_d_modules
+    all_d_modules=("$d_config/"+([0-9]).+([0-9]).+([0-9])/modules)
+    ((${#all_d_modules[@]})) || die 'ERROR: Discord modules directory not found.' \
+        'Try specifying it with --d-modules.'
+    d_modules=${all_d_modules[-1]}
+    verbose 1 "V: Found modules in $d_modules"
+  fi
 }
 
 bdc_kill() {
-  printf 'Killing Discord %s processes...\n' "$d_flavor" >&2
-  pkill -exi -KILL "discord${d_flavor:0:8}" || printf 'No active processes found.\n' >&2
+  >&2 printf 'Killing Discord %s processes...\n' "$d_flavor"
+  pkill -exi -KILL "discord${d_flavor:0:8}" || >&2 printf 'No active processes found.\n'
 }
 
-bd_install_asar() {
-  verbose 2 "VV: BetterDiscord asar installation: $bd_asar_dest"
-  if [[ -z $bd_asar ]]; then
-    declare release=https://github.com/$bd_repo/releases/$bd_release
-    verbose 1 "VV: BetterDiscord release URL: $release"
-    verbose 1 "V: Downloading BetterDiscord asar..."
-    curl -LSso "$bd_asar_dest" --create-dirs \
-        "$release/download/betterdiscord.asar"
-  else
-    if [[ ${flatpak+x} ]] || [[ ${snap+x} ]]; then
-      verbose 'V: Copying BetterDiscord asar...'
-      install -D "$bd_asar" "$bd_asar_dest"
-    fi
+d_discover_config() {
+  [[ $xdg_config ]] || die "ERROR: XDG user config directory (\$XDG_CONFIG_HOME) not found."
+  case "$d_install" in
+    traditional)
+      for d_flavor in "${d_flavors[@]}"; do
+        verbose 2 "VV: Trying flavor '$d_flavor'"
+        d_config=$xdg_config/discord${d_flavor,,}
+        if [[ -d $d_config ]]; then
+          break
+        fi
+        >&2 printf 'WARN: Discord %s config directory not found (%s).\n' \
+            "$d_flavor" "$d_config"
+      done
+      ;;
+    snap|flatpak)
+      d_config=$xdg_config/discord
+      if [[ ! -d $d_config ]]; then
+        >&2 printf 'WARN: Discord %s config directory not found (%s).\n' \
+            "$d_install" "$d_config"
+      fi
+      ;;
+    *) die "ERROR: [d_discover_config] Unknown Discord install variant: $d_install" ;;
+  esac
+}
+
+bd_discover_config() {
+  [[ $xdg_config ]] || die "ERROR: XDG user config directory (\$XDG_CONFIG_HOME) not found."
+  case "$d_install" in
+    traditional|snap|flatpak)
+      bd_config=$xdg_config/BetterDiscord
+      ;;
+    *) die "ERROR: [bd_discover_config] Unknown Discord install variant: $d_install" ;;
+  esac
+}
+
+# TODO: Integrate $bd_remote into main & install
+
+bd_remote_init() {
+  case "$bd_remote" in
+    github) bd_remote_init_github ;;
+    url) bd_remote_init_url ;;
+    dir) bd_remote_init_dir ;;
+    *) die "ERROR: [bd remote init] Unknown remote type: $bd_remote" ;;
+  esac
+  verbose 2 "VV: BetterDiscord remote asar path: $bd_remote_asar"
+  bd_asar_name=${bd_remote_asar##*/}
+}
+bd_remote_init_github() {
+  bd_remote_url=https://github.com/$bd_remote_github_owner/$bd_remote_github_repo/releases/$bd_remote_github_release/download
+  verbose 2 "VV: BetterDiscord remote GitHub repository owner: $bd_remote_github_owner"
+  verbose 2 "VV: BetterDiscord remote GitHub repository name: $bd_remote_github_repo"
+  verbose 2 "VV: BetterDiscord remote GitHub repository release: $bd_remote_github_release"
+  bd_remote_init_url
+}
+bd_remote_init_url() {
+  bd_remote_dir=$bd_config/data
+  verbose 2 "VV: BetterDiscord remote URL: $bd_remote_url"
+  bd_remote_init_dir
+}
+bd_remote_init_dir() {
+  verbose 2 "VV: BetterDiscord remote directory: $bd_remote_dir"
+}
+
+bd_remote_install() {
+  case "$bd_remote" in
+    github) bd_remote_install_github ;;
+    url) bd_remote_install_url ;;
+    dir) bd_remote_install_dir ;;
+    *) die "ERROR: [bd remote install] Unknown remote type: $bd_remote" ;;
+  esac
+}
+bd_remote_install_github() {
+  verbose 2 "VV: Installing remote BetterDiscord (GitHub)..."
+  bd_remote_install_url
+}
+bd_remote_install_url() {
+  verbose 2 "VV: Installing remote BetterDiscord (URL)..."
+  verbose 1 "V: Downloading BetterDiscord asar..."
+  curl -LSso "$bd_remote_dir/$bd_remote_asar" --create-dirs \
+      "$bd_remote_url/$bd_remote_asar"
+  bd_remote_install_dir
+}
+bd_remote_install_dir() {
+  verbose 2 "VV: Installing remote BetterDiscord (directory)..."
+  if [[ "$bd_remote_dir/$bd_remote_asar" != "$bd_asar" ]]; then
+    verbose 1 "V: Copying BetterDiscord asar..."
+    install -Dm 644 "$bd_remote_dir/$bd_remote_asar" "$bd_asar"
   fi
 }
 
 bdc_clean_legacy() {
   if [[ -d $d_core/core ]]; then
-    printf 'Removing legacy core directory...\n' >&2
+    >&2 printf 'Removing legacy core directory...\n'
     rm -rf "$d_core/core"
   fi
   if [[ -d $d_core/injector ]]; then
-    printf 'Removing legacy injector directory...\n' >&2
+    >&2 printf 'Removing legacy injector directory...\n'
     rm -rf "$d_core/injector"
   fi
   if [[ -d $bdc_data ]]; then
     if [[ -f "$bdc_data/bd_map" || -d "$bdc_data/bd" ]]; then
-      printf 'Removing legacy machine-specific data...\n' >&2
+      >&2 printf 'Removing legacy machine-specific data...\n'
       rm -rf "$bdc_data/bd_map" "$bdc_data/bd"
     fi
   fi
 }
 
-bd_patch() {
+bd_install() {
   verbose 1 'V: Injecting into index.js...'
-  declare escaped_asar=${bd_asar_dest/\\/\\\\}
   printf $'require("%s");
 module.exports = require(\'./core.asar\');
-' "${escaped_asar//\"/\\\"}" > "$d_core/index.js"
+' "$bd_asar_escaped" > "$d_core/index.js"
 }
 
-bd_unpatch() {
+bd_uninstall() {
   verbose 1 'V: Removing BetterDiscord injection...'
   printf $'module.exports = require(\'./core.asar\');
 ' > "$d_core/index.js"
@@ -465,10 +678,8 @@ case "$cmd" in
     bdc_main
     bdc_uninstall
     ;;
-  upgrade)
-    bdc_upgrade
+  self-upgrade)
+    bdc_self_upgrade
     ;;
-  *)
-    die "ERROR: Unknown command: $cmd"
-    ;;
+  *) die "ERROR: Unknown command (in command dispatch): $cmd" ;;
 esac

--- a/betterdiscordctl
+++ b/betterdiscordctl
@@ -578,81 +578,65 @@ bd_uninstall() {
 # Included from https://github.com/bb010g/Semver.sh , under the MIT License.
 
 Semver::validate() {
-  # shellcheck disable=SC2064
-  trap "$(shopt -p extglob)" RETURN
-  shopt -s extglob
+  [[ $1 =~ ^([^+-.]*)\.?([^+-.]*)\.?([^+-]*)(-?)([^+]*)(\+?)(.*)$ ]]
+  declare -a ver; ver=("${BASH_REMATCH[@]:1}")
 
-  declare normal=${1%%[+-]*}
-  declare extra=${1:${#normal}}
+  if [[ ${ver[0]} != +([0-9]) ]]; then printf '%s\n' "Semver::validate: invalid major: ${ver[0]}" >&2; return 1; fi
+  if [[ ${ver[1]} != +([0-9]) ]]; then printf '%s\n' "Semver::validate: invalid minor: ${ver[1]}" >&2; return 1; fi
+  if [[ ${ver[2]} != +([0-9]) ]]; then printf '%s\n' "Semver::validate: invalid patch: ${ver[2]}" >&2; return 1; fi
 
-  declare major=${normal%%.*}
-  if [[ $major != +([0-9]) ]]; then echo "Semver::validate: invalid major: $major" >&2; return 1; fi
-  normal=${normal:${#major}+1}
-  declare minor=${normal%%.*}
-  if [[ $minor != +([0-9]) ]]; then echo "Semver::validate: invalid minor: $minor" >&2; return 1; fi
-  declare patch=${normal:${#minor}+1}
-  if [[ $patch != +([0-9]) ]]; then echo "Semver::validate: invalid patch: $patch" >&2; return 1; fi
-
-  declare -r ident="+([0-9A-Za-z-])"
-  declare pre=${extra%%+*}
-  declare pre_len=${#pre}
-  if [[ $pre_len -gt 0 ]]; then
-    pre=${pre#-}
-    if [[ $pre != $ident*(.$ident) ]]; then echo "Semver::validate: invalid pre-release: $pre" >&2; return 1; fi
+  if [[ ${ver[3]} == '-' && ${ver[4]} != +([0-9A-Za-z-])*(.+([0-9A-Za-z-])) ]]; then
+    printf '%s\n' "Semver::validate: invalid pre-release: ${ver[4]}" >&2; return 1
   fi
-  declare build=${extra:pre_len}
-  if [[ ${#build} -gt 0 ]]; then
-    build=${build#+}
-    if [[ $build != $ident*(.$ident) ]]; then echo "Semver::validate: invalid build metadata: $build" >&2; return 1; fi
+  if [[ ${ver[5]} == '+' && ${ver[6]} != +([0-9A-Za-z-])*(.+([0-9A-Za-z-])) ]]; then
+    printf '%s\n' "Semver::validate: invalid build metadata: ${ver[6]}" >&2; return 1
   fi
 
-  if [[ $2 ]]; then
-    echo "$2=(${major@Q} ${minor@Q} ${patch@Q} ${pre@Q} ${build@Q})"
+  if [[ -n $2 ]]; then
+    printf '%s\n' "$2=(${ver[0]@Q} ${ver[1]@Q} ${ver[2]@Q} ${ver[4]@Q} ${ver[6]@Q})"
   else
-    echo "$1"
+    printf '%s\n' "$1"
   fi
 }
 
 Semver::compare() {
-  declare -a x y
-  eval "$(Semver::validate "$1" x)"
-  eval "$(Semver::validate "$2" y)"
+  declare -a xs ys
+  eval "$(Semver::validate "$1" xs)"
+  eval "$(Semver::validate "$2" ys)"
 
-  declare x_i y_i i
+  declare i x y
   for i in 0 1 2; do
-    x_i=${x[i]}; y_i=${y[i]}
-    if [[ $x_i -eq $y_i ]]; then continue; fi
-    if [[ $x_i -gt $y_i ]]; then echo 1; return; fi
-    if [[ $x_i -lt $y_i ]]; then echo -1; return; fi
+    x=${xs[i]}; y=${ys[i]}
+    if [[ $x -eq $y ]]; then continue; fi
+    if [[ $x -gt $y ]]; then echo 1; return; fi
+    if [[ $x -lt $y ]]; then echo -1; return; fi
   done
 
-  x_i=${x[3]}; y_i=${y[3]}
-  if [[ -z $x_i && $y_i ]]; then echo 1; return; fi
-  if [[ $x_i && -z $y_i ]]; then echo -1; return; fi
+  x=${xs[3]}; y=${ys[3]}
+  if [[ -z $x && -n $y ]]; then echo 1; return; fi
+  if [[ -n $x && -z $y ]]; then echo -1; return; fi
 
   declare -a x_pre; declare x_len
   declare -a y_pre; declare y_len
-  IFS=. read -ra x_pre <<< "$x_i"; x_len=${#x_pre[@]}
-  IFS=. read -ra y_pre <<< "$y_i"; y_len=${#y_pre[@]}
+  IFS=. read -ra x_pre <<< "$x."; x_len=${#x_pre[@]}
+  IFS=. read -ra y_pre <<< "$y."; y_len=${#y_pre[@]}
 
   if (( x_len > y_len )); then echo 1; return; fi
   if (( x_len < y_len )); then echo -1; return; fi
 
   for (( i=0; i < x_len; i++ )); do
-    x_i=${x_pre[i]}; y_i=${y_pre[i]}
-    if [[ $x_i = "$y_i" ]]; then continue; fi
+    x=${x_pre[i]}; y=${y_pre[i]}
+    if [[ $x == "$y" ]]; then continue; fi
 
-    declare num_x num_y
-    num_x=$([[ $x_i = +([0-9]) ]] && echo "$x_i")
-    num_y=$([[ $y_i = +([0-9]) ]] && echo "$y_i")
-    if [[ $num_x && $num_y ]]; then
-      if [[ $x_i -gt $y_i ]]; then echo 1; return; fi
-      if [[ $x_i -lt $y_i ]]; then echo -1; return; fi
+    if [[ $x == +([0-9]) ]]; then
+      if [[ $y == +([0-9]) ]]; then
+        if [[ $x -gt $y ]]; then echo 1; return; fi
+        if [[ $x -lt $y ]]; then echo -1; return; fi
+      else echo -1; return; fi
+    elif [[ $y == +([0-9]) ]]; then echo 1; return
     else
-      if [[ $num_y ]]; then echo 1; return; fi
-      if [[ $num_x ]]; then echo -1; return; fi
-      if [[ $x_i > $y_i ]]; then echo 1; return; fi
-      if [[ $x_i < $y_i ]]; then echo -1; return; fi
+      if [[ $x > $y ]]; then echo 1; return; fi
+      if [[ $x < $y ]]; then echo -1; return; fi
     fi
   done
 

--- a/betterdiscordctl
+++ b/betterdiscordctl
@@ -20,8 +20,11 @@ bd_repo_branch=injector
 bd=
 copy_bd=
 snap=
+snap_bin=snap
 flatpak=
+flatpak_bin=flatpak
 nix=
+nix_store_bin='nix-store'
 upgrade_url='https://github.com/bb010g/betterdiscordctl/raw/master/betterdiscordctl'
 
 # Variables
@@ -29,9 +32,6 @@ flavor=
 core=
 xdg_config=${XDG_CONFIG_HOME:-$HOME/.config}
 data=${XDG_DATA_HOME:-$HOME/.local/share}/betterdiscordctl
-snap_bin=snap
-flatpak_bin=flatpak
-nix_store_bin='nix-store'
 
 show_help() {
   cat << EOF
@@ -45,18 +45,18 @@ Options:
                                  a Discord installation
   -f, --flavors=FLAVORS          Colon-separated list of Discord flavors
   -d, --discord=DIRECTORY        Use the specified Discord directory
-                                 (requires --modules)
+                                 (requires "--modules")
   -m, --modules=DIRECTORY        Use the specified Discord modules directory
   -r, --bd-repo=REPOSITORY       Use the specified Git repo for BetterDiscord
       --bd-repo-branch=BRANCH    Use the specified Git branch for BetterDiscord
   -b, --betterdiscord=DIRECTORY  Use the specified BetterDiscord directory
   -c, --copy-bd                  Copy BD directory instead of symlinking
-      --snap[=COMMAND]           Use the Snap version of Discord (optionally
-                                 using the specified snap command)
-      --flatpak[=COMMAND]        Use the Flatpak version of Discord (optionally
-                                 using the specified flatpak command)
-      --nix[=COMMAND]            Look for Discord in the nix store (optionally
-                                 using the specified nix-store command)
+      --snap                     Use the Snap version of Discord
+      --snap-bin=EXECUTABLE      Use the specified "snap" executable
+      --flatpak                  Use the Flatpak version of Discord
+      --flatpak-bin=EXECUTABLE   Use the specified "flatpak" executable
+      --nix                      Look for Discord in the Nix store
+      --nix-store-bin=EXECUTABLE Use the specified "nix-store" executable
       --upgrade-url=URL          Custom URL to upgrade betterdiscordctl with
 
 Commands:
@@ -169,28 +169,29 @@ while :; do
       snap=yes
       copy_bd=yes
       ;;
-    --snap=?*)
-      snap=yes
-      copy_bd=yes
-      snap_bin=${1#*=}
+    --snap=*) die_no_option "${1%%=*}" ;;
+    --snap-bin)
+      if [[ ${2:+x} ]]; then snap_bin=$2; shift
+      else die_non_empty_option "$1"; fi
       ;;
-    --snap=) die_non_empty_option "${1%%=*}" ;;
-    --flatpak)
-      flatpak=yes
-      copy_bd=yes
+    --snap-bin=?*) snap_bin=${1#*=} ;;
+    --snap-bin=) die_non_empty_option "${1%%=*}" ;;
+    --flatpak) flatpak=yes ;;
+    --flatpak=*) die_no_option "${1%%=*}" ;;
+    --flatpak-bin)
+      if [[ ${2:+x} ]]; then flatpak_bin=$2; shift
+      else die_non_empty_option "$1"; fi
       ;;
-    --flatpak=?*)
-      flatpak=yes
-      copy_bd=yes
-      flatpak_bin=${1#*=}
-      ;;
-    --flatpak=) die_non_empty_option "${1%%=*}" ;;
+    --flatpak-bin=?*) flatpak_bin=${1#*=} ;;
+    --flatpak-bin=) die_non_empty_option "${1%%=*}" ;;
     --nix) nix=yes ;;
-    --nix=?*)
-      nix=yes
-      nix_store_bin=${1#*=}
+    --nix=*) die_no_option "${1%%=*}" ;;
+    --nix-store-bin)
+      if [[ ${2:+x} ]]; then nix_store_bin=$2; shift
+      else die_non_empty_option "$1"; fi
       ;;
-    --nix=) die_non_empty_option "${1%%=*}" ;;
+    --nix-store-bin=?*) nix_store_bin=${1#*=} ;;
+    --nix-store-bin=) die_non_empty_option "${1%%=*}" ;;
     --upgrade-url)
       if [[ ${2:+x} ]]; then upgrade_url=$2; shift
       else die_non_empty_option "$1"; fi

--- a/betterdiscordctl
+++ b/betterdiscordctl
@@ -247,12 +247,7 @@ Linked injector repository: %s\n' \
 
 bdc_install() {
   [[ -d $core/injector ]] && die 'ERROR: Already installed.'
-
-  # Clean up legacy cruft
-  if [[ -d $core/core ]]; then
-    printf 'Removing legacy core directory...\n' >&2
-    rm -rf "$core/core"
-  fi
+  bdc_clean_legacy
 
   bd_patch
   bd_injector
@@ -262,6 +257,7 @@ bdc_install() {
 
 bdc_reinstall() {
   [[ -d $core/injector ]] || die 'Not installed.'
+  bdc_clean_legacy
 
   bdc_kill
 
@@ -276,6 +272,7 @@ bdc_reinstall() {
 
 bdc_update() {
   [[ -d $core/injector ]] || die 'Not installed.'
+  bdc_clean_legacy
 
   if ! pushd "$core/injector" >/dev/null; then
     if [[ -h $core/injector ]]; then
@@ -296,6 +293,7 @@ bdc_update() {
 
 bdc_uninstall() {
   [[ -d $core/injector ]] || die 'Not installed.'
+  bdc_clean_legacy
 
   bdc_kill
   bd_unpatch
@@ -503,6 +501,13 @@ bd_injector() {
   else
     verbose 1 'V: Linking BetterDiscord injector...'
     ln -s "$bd" "$core/injector"
+  fi
+}
+
+bdc_clean_legacy() {
+  if [[ -d $core/core ]]; then
+    printf 'Removing legacy core directory...\n' >&2
+    rm -rf "$core/core"
   fi
 }
 

--- a/betterdiscordctl
+++ b/betterdiscordctl
@@ -11,20 +11,15 @@ DISABLE_UPGRADE=
 # Options
 cmd=status
 verbosity=0
-scan=(/opt /usr/share /usr/lib64)
 flavors=('' canary ptb)
-discord=
 modules=
-bd_repo='https://github.com/rauenzi/BetterDiscordApp'
-bd_repo_branch=injector
-bd=
-copy_bd=
-snap=
-snap_bin=snap
+bd_repo='rauenzi/BetterDiscordApp'
+bd_release=latest
+bd_asar=
 flatpak=
 flatpak_bin=flatpak
-nix=
-nix_store_bin='nix-store'
+snap=
+snap_bin=snap
 upgrade_url='https://github.com/bb010g/betterdiscordctl/raw/master/betterdiscordctl'
 
 # Variables
@@ -32,6 +27,9 @@ flavor=
 core=
 xdg_config=${XDG_CONFIG_HOME:-$HOME/.config}
 data=${XDG_DATA_HOME:-$HOME/.local/share}/betterdiscordctl
+discord_config=
+bd_config=$xdg_config/BetterDiscord
+bd_asar_dest=$bd_config/data/betterdiscord.asar
 
 show_help() {
   cat << EOF
@@ -41,29 +39,22 @@ Options:
   -V, --version                  Display version info and exit
   -h, --help                     Display this help message and exit
   -v, --verbose                  Increase verbosity
-  -s, --scan=DIRECTORIES         Colon-separated list of directories to scan for
-                                 a Discord installation
   -f, --flavors=FLAVORS          Colon-separated list of Discord flavors
-  -d, --discord=DIRECTORY        Use the specified Discord directory
-                                 (requires "--modules")
+                                 (default: ":canary:ptb")
   -m, --modules=DIRECTORY        Use the specified Discord modules directory
-  -r, --bd-repo=REPOSITORY       Use the specified Git repo for BetterDiscord
-      --bd-repo-branch=BRANCH    Use the specified Git branch for BetterDiscord
-  -b, --betterdiscord=DIRECTORY  Use the specified BetterDiscord directory
-  -c, --copy-bd                  Copy BD directory instead of symlinking
-      --snap                     Use the Snap version of Discord
-      --snap-bin=EXECUTABLE      Use the specified "snap" executable
+  -r, --bd-repo=REPOSITORY       Use the specified git repo for BetterDiscord
+  -R, --bd-release=RELEASE       Use the specified release for BetterDiscord
+  -a, --bd-asar=FILE             Use the specified betterdiscord.asar file
       --flatpak                  Use the Flatpak version of Discord
       --flatpak-bin=EXECUTABLE   Use the specified "flatpak" executable
-      --nix                      Look for Discord in the Nix store
-      --nix-store-bin=EXECUTABLE Use the specified "nix-store" executable
+      --snap                     Use the Snap version of Discord
+      --snap-bin=EXECUTABLE      Use the specified "snap" executable
       --upgrade-url=URL          Custom URL to upgrade betterdiscordctl with
 
 Commands:
   status (default)               Show the current Discord patch state.
   install                        Install BetterDiscord.
   reinstall                      Reinstall BetterDiscord.
-  update                         Update BetterDiscord.
   uninstall                      Uninstall BetterDiscord.
   upgrade                        Update betterdiscordctl.
 EOF
@@ -77,7 +68,7 @@ verbose() {
 }
 
 die() {
-  while [ $# -gt 0 ]; do
+  while (( $# > 0 )); do
     printf '%s\n' "$1" >&2
     shift
   done
@@ -103,7 +94,7 @@ die_non_empty_option() {
 while :; do
   if [[ -z ${1+x} ]]; then break; fi
   case $1 in
-    status|install|reinstall|update|uninstall|upgrade)
+    status|install|reinstall|uninstall|upgrade)
       cmd=$1
       ;;
     -V|--version)
@@ -119,13 +110,6 @@ while :; do
       ((++verbosity))
       ;;
     -v=*|--verbose=*) die_no_option "${1%%=*}" ;;
-    -s|--scan)
-      if [[ ${2+x} ]]; then IFS=':' read -ra scan <<< "$2:"; shift
-      else die_option "$1"; fi
-      ;;
-    --scan=*)
-      IFS=':' read -ra scan <<< "${1#*=}:"
-      ;;
     -f|--flavors)
       if [[ ${2+x} ]]; then IFS=':' read -ra flavors <<< "$2:"; shift
       else die_option "$1"; fi
@@ -133,49 +117,30 @@ while :; do
     --flavors=*)
       IFS=':' read -ra flavors <<< "${1#*=}:"
       ;;
-    -d|--discord)
-      if [[ ${2:+x} ]]; then discord=$2; shift
-      else die_non_empty_option "$1"; fi
-      ;;
-    --discord=?*) discord=${1#*=} ;;
-    --discord=) die_non_empty_option "${1%%=*}" ;;
     -m|--modules)
       if [[ ${2:+x} ]]; then modules=$2; shift
       else die_non_empty_option "$1"; fi
       ;;
     --modules=?*) modules=${1#*=} ;;
     --modules=) die_non_empty_option "${1%%=*}" ;;
-    --bd-repo-branch)
-      if [[ ${2:+x} ]]; then bd_repo_branch=$2; shift
-      else die_non_empty_option "$1"; fi
-      ;;
-    --bd-repo-branch=?*) bd_repo_branch=${1#*=} ;;
-    --bd-repo-branch=) die_non_empty_option "${1%%=*}" ;;
     -r|--bd-repo)
       if [[ ${2:+x} ]]; then bd_repo=$2; shift
       else die_non_empty_option "$1"; fi
       ;;
     --bd-repo=?*) bd_repo=${1#*=} ;;
     --bd-repo=) die_non_empty_option "${1%%=*}" ;;
-    -b|--betterdiscord)
-      if [[ ${2:+x} ]]; then bd=$2; shift
+    -R|--bd-release)
+      if [[ ${2:+x} ]]; then bd_release=$2; shift
       else die_non_empty_option "$1"; fi
       ;;
-    --betterdiscord=?*) bd=${1#*=} ;;
-    --betterdiscord=) die_non_empty_option "${1%%=*}" ;;
-    -c|--copy-bd) copy_bd=yes ;;
-    -c=*|--copy-bd=*) die_no_option "${1%%=*}" ;;
-    --snap)
-      snap=yes
-      copy_bd=yes
-      ;;
-    --snap=*) die_no_option "${1%%=*}" ;;
-    --snap-bin)
-      if [[ ${2:+x} ]]; then snap_bin=$2; shift
+    --bd-release=?*) bd_release=${1#*=} ;;
+    --bd-release=) die_non_empty_option "${1%%=*}" ;;
+    -a|--bd-asar)
+      if [[ ${2:+x} ]]; then bd_asar=$2; shift
       else die_non_empty_option "$1"; fi
       ;;
-    --snap-bin=?*) snap_bin=${1#*=} ;;
-    --snap-bin=) die_non_empty_option "${1%%=*}" ;;
+    --bd-asar=?*) bd_asar=${1#*=} ;;
+    --bd-asar=) die_non_empty_option "${1%%=*}" ;;
     --flatpak) flatpak=yes ;;
     --flatpak=*) die_no_option "${1%%=*}" ;;
     --flatpak-bin)
@@ -184,14 +149,14 @@ while :; do
       ;;
     --flatpak-bin=?*) flatpak_bin=${1#*=} ;;
     --flatpak-bin=) die_non_empty_option "${1%%=*}" ;;
-    --nix) nix=yes ;;
-    --nix=*) die_no_option "${1%%=*}" ;;
-    --nix-store-bin)
-      if [[ ${2:+x} ]]; then nix_store_bin=$2; shift
+    --snap) snap=yes ;;
+    --snap=*) die_no_option "${1%%=*}" ;;
+    --snap-bin)
+      if [[ ${2:+x} ]]; then snap_bin=$2; shift
       else die_non_empty_option "$1"; fi
       ;;
-    --nix-store-bin=?*) nix_store_bin=${1#*=} ;;
-    --nix-store-bin=) die_non_empty_option "${1%%=*}" ;;
+    --snap-bin=?*) snap_bin=${1#*=} ;;
+    --snap-bin=) die_non_empty_option "${1%%=*}" ;;
     --upgrade-url)
       if [[ ${2:+x} ]]; then upgrade_url=$2; shift
       else die_non_empty_option "$1"; fi
@@ -211,100 +176,60 @@ while :; do
   shift
 done
 
-mkdir -p "$data"
-[[ -f $data/bd_map ]] || touch "$data/bd_map"
+# currently unused
+# mkdir -p "$data"
 
 # Commands
 
 bdc_status() {
+  asar_install=no
   index_mod=no
-  linked_dir=no
-  linked_repo=no
-  if [[ -d $core/injector ]]; then
-    if [[ -h $core/injector ]]; then
-      linked_dir=$(readlink "$core/injector")
-      if pushd "$core/injector" >/dev/null; then
-        linked_repo=$(git remote get-url origin 2>/dev/null || printf 'no\n')
-        popd >/dev/null
-      else
-        linked_dir="(broken link) $linked_dir"
-      fi
-    fi
+  verbose 2 "VV: BetterDiscord asar installation: $bd_asar_dest"
+  if [[ -h $bd_asar_dest && ! -f $bd_asar_dest ]]; then
+    asar_install='(broken link) no'
+  elif [[ -f $bd_asar_dest ]]; then
+    asar_install='(symbolic link) yes'
+  elif [[ -d $bd_config ]]; then
+    asar_install='(missing) no'
   fi
-  if [[ ! -f $core/index.js ]]; then
-    index_mod='(missing) no'
-  else
-    grep -q 'injector' "$core/index.js" && index_mod=yes
-  fi
+  grep -Fq 'betterdiscord.asar' "$core/index.js" && index_mod=yes
 
-  printf 'Discord: %s
-Modules: %s
+  printf 'Discord flavor: %s
+Discord modules: %s
+BetterDiscord directory: %s
+BetterDiscord asar installed: %s
 Index modified: %s
-Linked injector directory: %s
-Linked injector repository: %s\n' \
-    "$discord" "$modules" "$index_mod" "$linked_dir" "$linked_repo"
+' "$flavor" "$modules" "$bd_config" "$asar_install" "$index_mod"
 }
 
 bdc_install() {
-  [[ -d $core/injector ]] && die 'ERROR: Already installed.'
+  grep -Fq 'betterdiscord.asar' "$core/index.js" && die 'ERROR: Already installed.'
   bdc_clean_legacy
 
+  bd_install_asar
   bd_patch
-  bd_injector
 
   printf 'Installed. (Restart Discord if necessary.)\n' >&2
 }
 
 bdc_reinstall() {
-  [[ -d $core/injector ]] || die 'Not installed.'
+  grep -Fq 'betterdiscord.asar' "$core/index.js" || die 'ERROR: Not installed.'
   bdc_clean_legacy
 
   bdc_kill
 
-  verbose 1 'V: Removing old injector folder.'
-  rm -rf "$core/injector"
-
+  bd_install_asar
   bd_patch
-  bd_injector
 
   printf 'Reinstalled.\n' >&2
 }
 
-bdc_update() {
-  [[ -d $core/injector ]] || die 'Not installed.'
-  bdc_clean_legacy
-
-  if ! pushd "$core/injector" >/dev/null; then
-    if [[ -h $core/injector ]]; then
-      die 'ERROR: BetterDiscord injector symbolic link is broken.'
-    else
-      die 'ERROR: BetterDiscord injector location is not a directory.'
-    fi
-  fi
-  if git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
-    printf 'Updating Git repository...\n' >&2
-    git fetch origin "$bd_repo_branch"
-    git reset --hard FETCH_HEAD
-  else
-    printf 'WARN: No Git repository found.\n' >&2
-  fi
-  popd >/dev/null
-}
-
 bdc_uninstall() {
-  [[ -d $core/injector ]] || die 'Not installed.'
+  grep -Fq 'betterdiscord.asar' "$core/index.js" || die 'ERROR: Not installed.'
   bdc_clean_legacy
 
   bdc_kill
   bd_unpatch
-
-  # Remove managed BD repo if applicable
-  bd_n=$(bd_map_get_dir "$discord" | bd_map_entry_n)
-  bd_map_remove "$discord"
-  if [[ -z $(bd_map_get_n "$bd_n") ]]; then
-    verbose 2 "VV: Removing $data/bd/$bd_n"
-    rm -rf "$data/bd/$bd_n"
-  fi
 
   printf 'Uninstalled.\n' >&2
 }
@@ -334,9 +259,11 @@ bdc_upgrade() {
     fi
   else
     if [[ $semver_diff -eq 0 ]]; then
-      printf 'betterdiscordctl is already the latest version (%s).\n' "$VERSION" >&2
+      printf 'betterdiscordctl is already the latest version (%s).\n' \
+          "$VERSION" >&2
     else
-      printf 'Local version (%s) is higher than GitHub version (%s).\n' "$VERSION" "$github_version" >&2
+      printf 'Local version (%s) is higher than GitHub version (%s).\n' \
+          "$VERSION" "$github_version" >&2
     fi
   fi
 }
@@ -344,53 +271,41 @@ bdc_upgrade() {
 # Implementation functions
 
 bdc_main() {
-  if [[ -z $discord ]]; then
-    if [[ $snap ]]; then bdc_snap
-    elif [[ $flatpak ]]; then bdc_flatpak
-    elif [[ $nix ]]; then bdc_nix
+  if [[ -z $modules ]]; then
+    if [[ $flatpak ]]; then bdc_flatpak
+    elif [[ $snap ]]; then bdc_snap
     else bdc_scan; fi
   else
-    flavor=$flavors
-    # --discord and --modules
-    [[ -z $modules ]] && die_with_help 'ERROR: "--discord" requires "--modules" to also be set.'
-    [[ -d $discord ]] || die 'ERROR: Discord installation not found.'
     [[ -d $modules ]] || die 'ERROR: Discord modules directory not found.'
+    flavor=${modules%/*/modules}
+    flavor=${flavor##*/discord}
   fi
-  [[ -d $discord ]] || die 'ERROR: Discord installation not found. Try specifying it with "--discord".'
+  [[ -d $modules ]] || die 'ERROR: Discord modules directory not found.' \
+      'Try specifying it with "--modules".'
   core=$modules/discord_desktop_core
-  [[ -d $core ]] || die "ERROR: Directory 'discord_desktop_core' not found in $(readlink -f "$modules")"
+  [[ -d $core ]] || die "ERROR: Directory 'discord_desktop_core' not found in $modules"
 }
 
 bdc_scan() {
-  for scandir in "${scan[@]}"; do
-    verbose 2 "VV: Scanning $scandir"
-    for flavor in "${flavors[@]}"; do
-      verbose 2 "VV: Trying flavor '$flavor'"
-      shopt -s nocaseglob
-      for discord in "$scandir"/discord?(-)"$flavor"; do
-        shopt -u nocaseglob
-        if [[ -d $discord ]]; then
-          verbose 1 "V: Using Discord at $discord"
-          discord_config=$xdg_config/discord${flavor,,}
-          if [[ ! -d $discord_config ]]; then
-            printf 'WARN: Config directory not found for Discord %s (%s, %s).\n' \
-              "$flavor" "$discord" "$discord_config" >&2
-            continue 2
-          fi
-          if [[ -z $modules ]]; then
-            bdc_find_modules
-          else
-            # --modules
-            [[ -d $modules ]] || die 'ERROR: Discord modules directory not found.'
-          fi
-          break 3
-        fi
-      done
-    done
+  for flavor in "${flavors[@]}"; do
+    verbose 2 "VV: Trying flavor '$flavor'"
+    discord_config=$xdg_config/discord${flavor,,}
+    if [[ ! -d $discord_config ]]; then
+      printf 'WARN: Discord %s config directory not found (%s).\n' \
+          "$flavor" "$discord_config" >&2
+      continue
+    fi
+    if [[ -z $modules ]]; then
+      bdc_find_modules
+    elif [[ ! -d $modules ]]; then
+      die 'ERROR: Discord modules directory not found.'
+    fi
+    break
   done
 }
 
 bdc_find_modules() {
+  [[ -d $discord_config ]] || die "ERROR: Discord $flavor config directory not found ($discord_config)."
   declare -a all_modules
   all_modules=("$discord_config/"+([0-9]).+([0-9]).+([0-9])/modules)
   ((${#all_modules[@]})) || die 'ERROR: Discord modules directory not found.'
@@ -401,106 +316,43 @@ bdc_find_modules() {
 bdc_snap() {
   # shellcheck disable=SC2016
   # Expansion should happen inside snap's shell.
-  snap_location=$("$snap_bin" run --shell discord <<< $'printf -- \'%s\n\' "$SNAP" 1>&3' 3>&1)
-  discord=${snap_location:?}/usr/share/discord
-  verbose 2 "VV: Checking $discord"
-  if [[ -d $discord ]]; then
-    verbose 1 "V: Using Discord at $discord"
-    # shellcheck disable=SC2016
-    # Expansion should happen inside snap's shell.
-    xdg_config=$("$snap_bin" run --shell discord <<< $'printf -- \'%s/.config\n\' "$SNAP_USER_DATA" 1>&3' 3>&1)
-    discord_config=$xdg_config/discord
-    bdc_find_modules
-  else
-    die 'ERROR: Discord installation not found.'
-  fi
+  xdg_config=$("$snap_bin" run --shell discord \
+      <<< $'printf -- \'%s/.config\n\' "$SNAP_USER_DATA" 1>&3' 3>&1)
+  discord_config=$xdg_config/discord
+  bd_config=$xdg_config/BetterDiscord
+  bd_asar_dest=$bd_config/data/betterdiscord.asar
+  bdc_find_modules
 }
 
 bdc_flatpak() {
-  flatpak_version=$("$flatpak_bin" --version | sed -n 's/Flatpak //p')
-  if [[ $(Semver::compare "$flatpak_version" '1.0.0') -eq -1 ]]; then
-    die 'ERROR: You are using an unsupported version of Flatpak.' \
-        'See https://github.com/bb010g/betterdiscordctl/issues/45'
-  fi
-  # flatpak sucks and doesn't use stderr for warnings.
-  # https://github.com/flatpak/flatpak/blob/13e449b/app/flatpak-main.c#L259-L286
-  # This really should be better for directories with newlines, but...
-  # We're just going to grab the last line and hope for the best.
-  flatpak_location=$("$flatpak_bin" info --show-location com.discordapp.Discord)
-  flatpak_location=${flatpak_location##*$'\n'}
-  if [[ -d ${flatpak_location:?}/files/discord ]]; then
-    discord=$flatpak_location/files/discord
-  else
-    discord=$flatpak_location/files/extra
-  fi
-  verbose 2 "VV: Checking $discord"
-  if [[ -d $discord ]]; then
-    verbose 1 "V: Using Discord at $discord"
-    # shellcheck disable=SC2016
-    # Expansion should happen inside flatpak's shell.
-    flatpak_config=$("$flatpak_bin" run --command=sh com.discordapp.Discord -c $'printf -- \'%s\n\' "$XDG_CONFIG_HOME"')
-    discord_config=${flatpak_config:-$HOME/.var/app/com.discordapp.Discord/config}/discord
-    if [[ ! -d $discord_config ]]; then
-      printf 'WARN: Config directory not found for Discord (%s, %s).\n' "$discord" "$discord_config" >&2
-    fi
-    bdc_find_modules
-  else
-    die 'ERROR: Discord installation not found.'
-  fi
-}
-
-bdc_nix() {
-  for flavor in "${flavors[@]}"; do
-    verbose 2 "VV: Trying flavor '$flavor'"
-    if [[ ${flavor,,} == ptb ]]; then
-      flavor=PTB
-    elif [[ ${flavor,,} == canary ]]; then
-      flavor=Canary
-    fi
-    scandir=$("$nix_store_bin" -r "$(which "Discord$flavor")")
-    verbose 2 "VV: Scanning $scandir"
-    discord="$scandir/opt/Discord$flavor"
-    if [[ -d $discord ]]; then
-      verbose 1 "V: Using Discord at $discord"
-      discord_config=$xdg_config/discord${flavor,,}
-      if [[ ! -d $discord_config ]]; then
-        printf 'WARN: Config directory not found for Discord %s (%s, %s).\n' \
-          "$flavor" "$discord" "$discord_config" >&2
-        continue
-      fi
-      if [[ -z $modules ]]; then
-        bdc_find_modules
-      else
-        # --modules
-        [[ -d $modules ]] || die 'ERROR: Discord modules directory not found.'
-      fi
-      break
-    fi
-  done
+  # shellcheck disable=SC2016
+  # Expansion should happen inside flatpak's shell.
+  xdg_config=$("$flatpak_bin" run --command=sh com.discordapp.Discord \
+      -c $'printf -- \'%s\n\' "$XDG_CONFIG_HOME"')
+  discord_config=${xdg_config:-$HOME/.var/app/com.discordapp.Discord/config}/discord
+  bd_config=$xdg_config/BetterDiscord
+  bd_asar_dest=$bd_config/data/betterdiscord.asar
+  bdc_find_modules
 }
 
 bdc_kill() {
-  declare process_name=Discord
-  [[ $flavor ]] && process_name+=" $flavor"
-  printf 'Killing %s processes...\n' "$process_name" >&2
+  printf 'Killing Discord %s processes...\n' "$flavor" >&2
   pkill -exi -KILL "discord${flavor:0:8}" || printf 'No active processes found.\n' >&2
 }
 
-bd_injector() {
-  if [[ -z $bd ]]; then
-    bd=$data/bd/$(bd_map_add "$discord" "$bd_repo")
-    if [[ ! -d $bd ]]; then
-      printf 'Cloning %s...\n' "$bd_repo" >&2
-      git clone "$bd_repo" -b "$bd_repo_branch" --depth=1 --single-branch "$bd"
-    fi
-  fi
-
-  if [[ $copy_bd ]]; then
-    verbose 1 'V: Copying BetterDiscord injector...'
-    cp -r "$bd" "$core/injector"
+bd_install_asar() {
+  verbose 2 "VV: BetterDiscord asar installation: $bd_asar_dest"
+  if [[ -z $bd_asar ]]; then
+    declare release=https://github.com/$bd_repo/releases/$bd_release
+    verbose 1 "VV: BetterDiscord release URL: $release"
+    verbose 1 "V: Downloading BetterDiscord asar..."
+    curl -LSso "$bd_asar_dest" --create-dirs \
+        "$release/download/betterdiscord.asar"
   else
-    verbose 1 'V: Linking BetterDiscord injector...'
-    ln -s "$bd" "$core/injector"
+    if [[ ${flatpak+x} ]] || [[ ${snap+x} ]]; then
+      verbose 'V: Copying BetterDiscord asar...'
+      install -D "$bd_asar" "$bd_asar_dest"
+    fi
   fi
 }
 
@@ -509,60 +361,30 @@ bdc_clean_legacy() {
     printf 'Removing legacy core directory...\n' >&2
     rm -rf "$core/core"
   fi
+  if [[ -d $core/injector ]]; then
+    printf 'Removing legacy injector directory...\n' >&2
+    rm -rf "$core/injector"
+  fi
+  if [[ -d $data ]]; then
+    if [[ -f "$data/bd_map" || -d "$data/bd" ]]; then
+      printf 'Removing legacy machine-specific data...\n' >&2
+      rm -rf "$data/bd_map" "$data/bd"
+    fi
+  fi
 }
 
 bd_patch() {
-  if ! grep -q 'injector' "$core/index.js"; then
-    verbose 1 'V: Injecting into index.js...'
-    sed -i "$core/index.js" \
-      -e "1i require('./injector');" \
-      -e "s/core'/core.asar'/"
-  fi
+  verbose 1 'V: Injecting into index.js...'
+  declare escaped_asar=${bd_asar_dest/\\/\\\\}
+  printf $'require("%s");
+module.exports = require(\'./core.asar\');
+' "${escaped_asar//\"/\\\"}" > "$core/index.js"
 }
 
 bd_unpatch() {
   verbose 1 'V: Removing BetterDiscord injection...'
-  sed -i "$core/index.js" \
-    -e '/injector/d' \
-    -e "s/core'/core.asar'/"
-  rm -rf "$core/injector"
-}
-
-bd_map_entry_n() {
-  sed 's/^.*\t\t.*\t\(.*\)$/\1/' "$@"
-}
-
-bd_map_fresh() {
-  verbose 2 'VV: Generating fresh bd_map number...'
-  bd_map_entry_n "$data/bd_map" | sort | awk \
-    'BEGIN {max=-1} NF != 0 {if ($1>max+1) {exit}; max=$1} END {print max+1}'
-}
-
-bd_map_add() {
-  entry=$(bd_map_get_repo "$2")
-  if [[ $entry ]]; then
-    num=$(head -n1 <<< "$entry" | bd_map_entry_n)
-  else
-    num=$(bd_map_fresh)
-  fi
-  printf '%s\t\t%s\t%s\n' "$1" "$2" "$num" >> "$data/bd_map"
-  printf '%s\n' "$num"
-}
-
-bd_map_get_dir() {
-  grep -F "$1"$'\t\t' "$data/bd_map"
-}
-
-bd_map_get_repo() {
-  grep -F $'\t\t'"$1"$'\t' "$data/bd_map"
-}
-
-bd_map_get_n() {
-  grep $'\t'"$1\$" "$data/bd_map"
-}
-
-bd_map_remove() {
-  sed -i "$data/bd_map" -e "\\%$1\\t\\t%d"
+  printf $'module.exports = require(\'./core.asar\');
+' > "$core/index.js"
 }
 
 # Included from https://github.com/bb010g/Semver.sh , under the MIT License.
@@ -663,10 +485,6 @@ case "$cmd" in
   reinstall)
     bdc_main
     bdc_reinstall
-    ;;
-  update)
-    bdc_main
-    bdc_update
     ;;
   uninstall)
     bdc_main

--- a/betterdiscordctl
+++ b/betterdiscordctl
@@ -110,73 +110,73 @@ while :; do
       ;;
     -s|--scan)
       if [[ ${2+x} ]]; then IFS=':' read -ra scan <<< "$2"; shift
-      else die_non_empty '--scan'; fi
+      else die_non_empty "$1"; fi
       ;;
     --scan=?*)
       IFS=':' read -ra scan <<< "${1#*=}"
       ;;
     --scan=)
-      die_non_empty '--scan'
+      die_non_empty "${1%%=*}"
       ;;
     -f|--flavors)
       if [[ ${2+x} ]]; then IFS=':' read -ra flavors <<< "$2"; shift
-      else die_non_empty '--flavors'; fi
+      else die_non_empty "$1"; fi
       ;;
     --flavors=?*)
       IFS=':' read -ra flavors <<< "${1#*=}"
       ;;
     --flavors=)
-      die_non_empty '--flavors'
+      die_non_empty "${1%%=*}"
       ;;
     -d|--discord)
       if [[ ${2+x} ]]; then discord=$2; shift
-      else die_non_empty '--discord'; fi
+      else die_non_empty "$1"; fi
       ;;
     --discord=?*)
       discord=${1#*=}
       ;;
     --discord=)
-      die_non_empty '--discord'
+      die_non_empty "${1%%=*}"
       ;;
     -m|--modules)
       if [[ ${2+x} ]]; then modules=$2; shift
-      else die_non_empty '--modules'; fi
+      else die_non_empty "$1"; fi
       ;;
     --modules=?*)
       modules=${1#*=}
       ;;
     --modules=)
-      die_non_empty '--modules'
+      die_non_empty "${1%%=*}"
       ;;
     --bd-repo-branch)
       if [[ ${2+x} ]]; then bd_repo_branch=$2; shift
-      else die_non_empty '--bd-repo-branch'; fi
+      else die_non_empty "$1"; fi
       ;;
     --bd-repo-branch=?*)
       bd_repo_branch=${1#*=}
       ;;
     --bd-repo-branch=)
-      die_non_empty '--bd-repo-branch'
+      die_non_empty "${1%%=*}"
       ;;
     -r|--bd-repo)
       if [[ ${2+x} ]]; then bd_repo=$2; shift
-      else die_non_empty '--bd-repo'; fi
+      else die_non_empty "$1"; fi
       ;;
     --bd-repo=?*)
       bd_repo=${1#*=}
       ;;
     --bd-repo=)
-      die_non_empty '--bd-repo'
+      die_non_empty "${1%%=*}"
       ;;
     -b|--betterdiscord)
       if [[ ${2+x} ]]; then bd=$2; shift
-      else die_non_empty '--betterdiscord'; fi
+      else die_non_empty "$1"; fi
       ;;
     --betterdiscord=?*)
       bd=${1#*=}
       ;;
     --betterdiscord=)
-      die_non_empty '--betterdiscord'
+      die_non_empty "${1%%=*}"
       ;;
     -c|--copy-bd)
       copy_bd=yes
@@ -191,7 +191,7 @@ while :; do
       snap_bin=${1#*=}
       ;;
     --snap=)
-      die_non_empty '--snap'
+      die_non_empty "${1%%=*}"
       ;;
     --flatpak)
       flatpak=yes
@@ -203,7 +203,7 @@ while :; do
       flatpak_bin=${1#*=}
       ;;
     --flatpak=)
-      die_non_empty '--flatpak'
+      die_non_empty "${1%%=*}"
       ;;
     --nix)
       nix=yes
@@ -213,17 +213,17 @@ while :; do
       nix_store_bin=${1#*=}
       ;;
     --nix=)
-      die_non_empty '--nix'
+      die_non_empty "${1%%=*}"
       ;;
     --upgrade-url)
       if [[ ${2+x} ]]; then upgrade_url=$2; shift
-      else die_non_empty '--upgrade-url'; fi
+      else die_non_empty "$1"; fi
       ;;
     --upgrade-url=?*)
       upgrade_url=${1#*=}
       ;;
     --upgrade-url=)
-      die_non_empty '--upgrade-url'
+      die_non_empty "${1%%=*}"
       ;;
     --)
       shift

--- a/betterdiscordctl
+++ b/betterdiscordctl
@@ -4,7 +4,7 @@ set -ueo pipefail
 shopt -s dotglob extglob nullglob
 
 # Constants
-VERSION=1.7.1
+VERSION=1.8.0
 SOURCE=$(readlink -f "${BASH_SOURCE[0]}")
 DISABLE_UPGRADE=
 

--- a/betterdiscordctl
+++ b/betterdiscordctl
@@ -88,6 +88,10 @@ die_with_help() {
   die "$@" 'Use "--help" for more information.'
 }
 
+die_no_option() {
+  die_with_help "ERROR: \"$1\" requires no option argument."
+}
+
 die_option() {
   die_with_help "ERROR: \"$1\" requires an option argument."
 }
@@ -106,11 +110,20 @@ while :; do
       printf 'betterdiscordctl %s\n' "$VERSION" >&2
       exit
       ;;
+    -V=*|--version=*)
+      die_no_option "${1%%=*}"
+      ;;
     -h|-\?|--help)
       show_help; exit
       ;;
+    -h=*|-\?=*|--help=*)
+      die_no_option "${1%%=*}"
+      ;;
     -v|--verbose)
       ((++verbosity))
+      ;;
+    -v=*|--verbose=*)
+      die_no_option "${1%%=*}"
       ;;
     -s|--scan)
       if [[ ${2+x} ]]; then IFS=':' read -ra scan <<< "$2:"; shift
@@ -178,6 +191,9 @@ while :; do
       ;;
     -c|--copy-bd)
       copy_bd=yes
+      ;;
+    -c=*|--copy-bd=*)
+      die_no_option "${1%%=*}"
       ;;
     --snap)
       snap=yes

--- a/betterdiscordctl
+++ b/betterdiscordctl
@@ -110,21 +110,15 @@ while :; do
       printf 'betterdiscordctl %s\n' "$VERSION" >&2
       exit
       ;;
-    -V=*|--version=*)
-      die_no_option "${1%%=*}"
-      ;;
+    -V=*|--version=*) die_no_option "${1%%=*}" ;;
     -h|-\?|--help)
       show_help; exit
       ;;
-    -h=*|-\?=*|--help=*)
-      die_no_option "${1%%=*}"
-      ;;
+    -h=*|-\?=*|--help=*) die_no_option "${1%%=*}" ;;
     -v|--verbose)
       ((++verbosity))
       ;;
-    -v=*|--verbose=*)
-      die_no_option "${1%%=*}"
-      ;;
+    -v=*|--verbose=*) die_no_option "${1%%=*}" ;;
     -s|--scan)
       if [[ ${2+x} ]]; then IFS=':' read -ra scan <<< "$2:"; shift
       else die_option "$1"; fi
@@ -143,58 +137,34 @@ while :; do
       if [[ ${2:+x} ]]; then discord=$2; shift
       else die_non_empty_option "$1"; fi
       ;;
-    --discord=?*)
-      discord=${1#*=}
-      ;;
-    --discord=)
-      die_non_empty_option "${1%%=*}"
-      ;;
+    --discord=?*) discord=${1#*=} ;;
+    --discord=) die_non_empty_option "${1%%=*}" ;;
     -m|--modules)
       if [[ ${2:+x} ]]; then modules=$2; shift
       else die_non_empty_option "$1"; fi
       ;;
-    --modules=?*)
-      modules=${1#*=}
-      ;;
-    --modules=)
-      die_non_empty_option "${1%%=*}"
-      ;;
+    --modules=?*) modules=${1#*=} ;;
+    --modules=) die_non_empty_option "${1%%=*}" ;;
     --bd-repo-branch)
       if [[ ${2:+x} ]]; then bd_repo_branch=$2; shift
       else die_non_empty_option "$1"; fi
       ;;
-    --bd-repo-branch=?*)
-      bd_repo_branch=${1#*=}
-      ;;
-    --bd-repo-branch=)
-      die_non_empty_option "${1%%=*}"
-      ;;
+    --bd-repo-branch=?*) bd_repo_branch=${1#*=} ;;
+    --bd-repo-branch=) die_non_empty_option "${1%%=*}" ;;
     -r|--bd-repo)
       if [[ ${2:+x} ]]; then bd_repo=$2; shift
       else die_non_empty_option "$1"; fi
       ;;
-    --bd-repo=?*)
-      bd_repo=${1#*=}
-      ;;
-    --bd-repo=)
-      die_non_empty_option "${1%%=*}"
-      ;;
+    --bd-repo=?*) bd_repo=${1#*=} ;;
+    --bd-repo=) die_non_empty_option "${1%%=*}" ;;
     -b|--betterdiscord)
       if [[ ${2:+x} ]]; then bd=$2; shift
       else die_non_empty_option "$1"; fi
       ;;
-    --betterdiscord=?*)
-      bd=${1#*=}
-      ;;
-    --betterdiscord=)
-      die_non_empty_option "${1%%=*}"
-      ;;
-    -c|--copy-bd)
-      copy_bd=yes
-      ;;
-    -c=*|--copy-bd=*)
-      die_no_option "${1%%=*}"
-      ;;
+    --betterdiscord=?*) bd=${1#*=} ;;
+    --betterdiscord=) die_non_empty_option "${1%%=*}" ;;
+    -c|--copy-bd) copy_bd=yes ;;
+    -c=*|--copy-bd=*) die_no_option "${1%%=*}" ;;
     --snap)
       snap=yes
       copy_bd=yes
@@ -204,9 +174,7 @@ while :; do
       copy_bd=yes
       snap_bin=${1#*=}
       ;;
-    --snap=)
-      die_non_empty_option "${1%%=*}"
-      ;;
+    --snap=) die_non_empty_option "${1%%=*}" ;;
     --flatpak)
       flatpak=yes
       copy_bd=yes
@@ -216,29 +184,19 @@ while :; do
       copy_bd=yes
       flatpak_bin=${1#*=}
       ;;
-    --flatpak=)
-      die_non_empty_option "${1%%=*}"
-      ;;
-    --nix)
-      nix=yes
-      ;;
+    --flatpak=) die_non_empty_option "${1%%=*}" ;;
+    --nix) nix=yes ;;
     --nix=?*)
       nix=yes
       nix_store_bin=${1#*=}
       ;;
-    --nix=)
-      die_non_empty_option "${1%%=*}"
-      ;;
+    --nix=) die_non_empty_option "${1%%=*}" ;;
     --upgrade-url)
       if [[ ${2:+x} ]]; then upgrade_url=$2; shift
       else die_non_empty_option "$1"; fi
       ;;
-    --upgrade-url=?*)
-      upgrade_url=${1#*=}
-      ;;
-    --upgrade-url=)
-      die_non_empty_option "${1%%=*}"
-      ;;
+    --upgrade-url=?*) upgrade_url=${1#*=} ;;
+    --upgrade-url=) die_non_empty_option "${1%%=*}" ;;
     --)
       shift
       break

--- a/betterdiscordctl
+++ b/betterdiscordctl
@@ -39,6 +39,7 @@ Options:
   -V, --version                  Display version info and exit
   -h, --help                     Display this help message and exit
   -v, --verbose                  Increase verbosity
+  -q, --quiet                    Decrease verbosity
   -f, --flavors=FLAVORS          Colon-separated list of Discord flavors
                                  (default: ":canary:ptb")
   -m, --modules=DIRECTORY        Use the specified Discord modules directory
@@ -107,9 +108,13 @@ while :; do
       ;;
     -h=*|-\?=*|--help=*) die_no_option "${1%%=*}" ;;
     -v|--verbose)
-      ((++verbosity))
+      ((verbosity++))
       ;;
     -v=*|--verbose=*) die_no_option "${1%%=*}" ;;
+    -q|--quiet)
+      ((verbosity--))
+      ;;
+    -q=*|--quiet=*) die_no_option "${1%%=*}" ;;
     -f|--flavors)
       if [[ ${2+x} ]]; then IFS=':' read -ra d_flavors <<< "$2:"; shift
       else die_option "$1"; fi

--- a/betterdiscordctl
+++ b/betterdiscordctl
@@ -80,10 +80,6 @@ die_with_help() {
   die "$@" 'Use "--help" for more information.'
 }
 
-die_no_option() {
-  die_with_help "ERROR: \"$1\" requires no option argument."
-}
-
 die_option() {
   die_with_help "ERROR: \"$1\" requires an option argument."
 }
@@ -102,81 +98,55 @@ while :; do
       printf 'betterdiscordctl %s\n' "$VERSION" >&2
       exit
       ;;
-    -V=*|--version=*) die_no_option "${1%%=*}" ;;
     -h|-\?|--help)
       show_help; exit
       ;;
-    -h=*|-\?=*|--help=*) die_no_option "${1%%=*}" ;;
     -v|--verbose)
       ((verbosity++))
       ;;
-    -v=*|--verbose=*) die_no_option "${1%%=*}" ;;
     -q|--quiet)
       ((verbosity--))
       ;;
-    -q=*|--quiet=*) die_no_option "${1%%=*}" ;;
     -f|--flavors)
       if [[ ${2+x} ]]; then IFS=':' read -ra d_flavors <<< "$2:"; shift
       else die_option "$1"; fi
-      ;;
-    --flavors=*)
-      IFS=':' read -ra d_flavors <<< "${1#*=}:"
       ;;
     -m|--modules)
       if [[ ${2:+x} ]]; then d_modules=$2; shift
       else die_non_empty_option "$1"; fi
       ;;
-    --modules=?*) d_modules=${1#*=} ;;
-    --modules=) die_non_empty_option "${1%%=*}" ;;
     -r|--bd-repo)
       if [[ ${2:+x} ]]; then bd_repo=$2; shift
       else die_non_empty_option "$1"; fi
       ;;
-    --bd-repo=?*) bd_repo=${1#*=} ;;
-    --bd-repo=) die_non_empty_option "${1%%=*}" ;;
     -R|--bd-release)
       if [[ ${2:+x} ]]; then bd_release=$2; shift
       else die_non_empty_option "$1"; fi
       ;;
-    --bd-release=?*) bd_release=${1#*=} ;;
-    --bd-release=) die_non_empty_option "${1%%=*}" ;;
     -a|--bd-asar)
       if [[ ${2:+x} ]]; then bd_asar=$2; shift
       else die_non_empty_option "$1"; fi
       ;;
-    --bd-asar=?*) bd_asar=${1#*=} ;;
-    --bd-asar=) die_non_empty_option "${1%%=*}" ;;
     --flatpak) flatpak=yes ;;
-    --flatpak=*) die_no_option "${1%%=*}" ;;
     --flatpak-bin)
       if [[ ${2:+x} ]]; then flatpak_bin=$2; shift
       else die_non_empty_option "$1"; fi
       ;;
-    --flatpak-bin=?*) flatpak_bin=${1#*=} ;;
-    --flatpak-bin=) die_non_empty_option "${1%%=*}" ;;
     --snap) snap=yes ;;
-    --snap=*) die_no_option "${1%%=*}" ;;
     --snap-bin)
       if [[ ${2:+x} ]]; then snap_bin=$2; shift
       else die_non_empty_option "$1"; fi
       ;;
-    --snap-bin=?*) snap_bin=${1#*=} ;;
-    --snap-bin=) die_non_empty_option "${1%%=*}" ;;
     --upgrade-url)
       if [[ ${2:+x} ]]; then upgrade_url=$2; shift
       else die_non_empty_option "$1"; fi
       ;;
-    --upgrade-url=?*) upgrade_url=${1#*=} ;;
-    --upgrade-url=) die_non_empty_option "${1%%=*}" ;;
-    --)
-      shift
-      break
-      ;;
-    -?*)
-      printf 'WARN: Unknown option (ignored): %s\n' "$1" >&2
-      ;;
-    *)
-      break
+    # footer
+    -*=*) die "ERROR: Keyed options must not be separated by equals: $1" ;;
+    --) shift; break ;;
+    -?|--*) die_with_help "ERROR: Unknown top-level option: $1" ;;
+    -??*) die "ERROR: Switches must not be ran together: $1" ;;
+    *) break
   esac
   shift
 done

--- a/betterdiscordctl
+++ b/betterdiscordctl
@@ -4,7 +4,7 @@ set -ueo pipefail
 shopt -s dotglob extglob nullglob
 
 # Constants
-VERSION=1.8.0
+VERSION=2.0.0
 SOURCE=$(readlink -f "${BASH_SOURCE[0]}")
 DISABLE_UPGRADE=
 

--- a/betterdiscordctl
+++ b/betterdiscordctl
@@ -113,24 +113,18 @@ while :; do
       ((++verbosity))
       ;;
     -s|--scan)
-      if [[ ${2:+x} ]]; then IFS=':' read -ra scan <<< "$2"; shift
-      else die_non_empty_option "$1"; fi
+      if [[ ${2+x} ]]; then IFS=':' read -ra scan <<< "$2:"; shift
+      else die_option "$1"; fi
       ;;
-    --scan=?*)
-      IFS=':' read -ra scan <<< "${1#*=}"
-      ;;
-    --scan=)
-      die_non_empty_option "${1%%=*}"
+    --scan=*)
+      IFS=':' read -ra scan <<< "${1#*=}:"
       ;;
     -f|--flavors)
-      if [[ ${2:+x} ]]; then IFS=':' read -ra flavors <<< "$2"; shift
-      else die_non_empty_option "$1"; fi
+      if [[ ${2+x} ]]; then IFS=':' read -ra flavors <<< "$2:"; shift
+      else die_option "$1"; fi
       ;;
-    --flavors=?*)
-      IFS=':' read -ra flavors <<< "${1#*=}"
-      ;;
-    --flavors=)
-      die_non_empty_option "${1%%=*}"
+    --flavors=*)
+      IFS=':' read -ra flavors <<< "${1#*=}:"
       ;;
     -d|--discord)
       if [[ ${2:+x} ]]; then discord=$2; shift

--- a/betterdiscordctl
+++ b/betterdiscordctl
@@ -11,8 +11,8 @@ DISABLE_UPGRADE=
 # Options
 cmd=status
 verbosity=0
-flavors=('' canary ptb)
-modules=
+d_flavors=('' canary ptb)
+d_modules=
 bd_repo='rauenzi/BetterDiscordApp'
 bd_release=latest
 bd_asar=
@@ -23,11 +23,11 @@ snap_bin=snap
 upgrade_url='https://github.com/bb010g/betterdiscordctl/raw/master/betterdiscordctl'
 
 # Variables
-flavor=
-core=
+d_flavor=
+d_core=
 xdg_config=${XDG_CONFIG_HOME:-$HOME/.config}
-data=${XDG_DATA_HOME:-$HOME/.local/share}/betterdiscordctl
-discord_config=
+bdc_data=${XDG_DATA_HOME:-$HOME/.local/share}/betterdiscordctl
+d_config=
 bd_config=$xdg_config/BetterDiscord
 bd_asar_dest=$bd_config/data/betterdiscord.asar
 
@@ -111,17 +111,17 @@ while :; do
       ;;
     -v=*|--verbose=*) die_no_option "${1%%=*}" ;;
     -f|--flavors)
-      if [[ ${2+x} ]]; then IFS=':' read -ra flavors <<< "$2:"; shift
+      if [[ ${2+x} ]]; then IFS=':' read -ra d_flavors <<< "$2:"; shift
       else die_option "$1"; fi
       ;;
     --flavors=*)
-      IFS=':' read -ra flavors <<< "${1#*=}:"
+      IFS=':' read -ra d_flavors <<< "${1#*=}:"
       ;;
     -m|--modules)
-      if [[ ${2:+x} ]]; then modules=$2; shift
+      if [[ ${2:+x} ]]; then d_modules=$2; shift
       else die_non_empty_option "$1"; fi
       ;;
-    --modules=?*) modules=${1#*=} ;;
+    --modules=?*) d_modules=${1#*=} ;;
     --modules=) die_non_empty_option "${1%%=*}" ;;
     -r|--bd-repo)
       if [[ ${2:+x} ]]; then bd_repo=$2; shift
@@ -177,7 +177,7 @@ while :; do
 done
 
 # currently unused
-# mkdir -p "$data"
+# mkdir -p "$bdc_data"
 
 # Commands
 
@@ -192,18 +192,18 @@ bdc_status() {
   elif [[ -d $bd_config ]]; then
     asar_install='(missing) no'
   fi
-  grep -Fq 'betterdiscord.asar' "$core/index.js" && index_mod=yes
+  grep -Fq 'betterdiscord.asar' "$d_core/index.js" && index_mod=yes
 
   printf 'Discord flavor: %s
 Discord modules: %s
 BetterDiscord directory: %s
 BetterDiscord asar installed: %s
 Index modified: %s
-' "$flavor" "$modules" "$bd_config" "$asar_install" "$index_mod"
+' "$d_flavor" "$d_modules" "$bd_config" "$asar_install" "$index_mod"
 }
 
 bdc_install() {
-  grep -Fq 'betterdiscord.asar' "$core/index.js" && die 'ERROR: Already installed.'
+  grep -Fq 'betterdiscord.asar' "$d_core/index.js" && die 'ERROR: Already installed.'
   bdc_clean_legacy
 
   bd_install_asar
@@ -213,7 +213,7 @@ bdc_install() {
 }
 
 bdc_reinstall() {
-  grep -Fq 'betterdiscord.asar' "$core/index.js" || die 'ERROR: Not installed.'
+  grep -Fq 'betterdiscord.asar' "$d_core/index.js" || die 'ERROR: Not installed.'
   bdc_clean_legacy
 
   bdc_kill
@@ -225,7 +225,7 @@ bdc_reinstall() {
 }
 
 bdc_uninstall() {
-  grep -Fq 'betterdiscord.asar' "$core/index.js" || die 'ERROR: Not installed.'
+  grep -Fq 'betterdiscord.asar' "$d_core/index.js" || die 'ERROR: Not installed.'
   bdc_clean_legacy
 
   bdc_kill
@@ -271,33 +271,33 @@ bdc_upgrade() {
 # Implementation functions
 
 bdc_main() {
-  if [[ -z $modules ]]; then
+  if [[ -z $d_modules ]]; then
     if [[ $flatpak ]]; then bdc_flatpak
     elif [[ $snap ]]; then bdc_snap
     else bdc_scan; fi
   else
-    [[ -d $modules ]] || die 'ERROR: Discord modules directory not found.'
-    flavor=${modules%/*/modules}
-    flavor=${flavor##*/discord}
+    [[ -d $d_modules ]] || die 'ERROR: Discord modules directory not found.'
+    d_flavor=${d_modules%/*/modules}
+    d_flavor=${d_flavor##*/discord}
   fi
-  [[ -d $modules ]] || die 'ERROR: Discord modules directory not found.' \
+  [[ -d $d_modules ]] || die 'ERROR: Discord modules directory not found.' \
       'Try specifying it with "--modules".'
-  core=$modules/discord_desktop_core
-  [[ -d $core ]] || die "ERROR: Directory 'discord_desktop_core' not found in $modules"
+  d_core=$d_modules/discord_desktop_core
+  [[ -d $d_core ]] || die "ERROR: Directory 'discord_desktop_core' not found in $d_modules"
 }
 
 bdc_scan() {
-  for flavor in "${flavors[@]}"; do
-    verbose 2 "VV: Trying flavor '$flavor'"
-    discord_config=$xdg_config/discord${flavor,,}
-    if [[ ! -d $discord_config ]]; then
+  for d_flavor in "${d_flavors[@]}"; do
+    verbose 2 "VV: Trying flavor '$d_flavor'"
+    d_config=$xdg_config/discord${d_flavor,,}
+    if [[ ! -d $d_config ]]; then
       printf 'WARN: Discord %s config directory not found (%s).\n' \
-          "$flavor" "$discord_config" >&2
+          "$d_flavor" "$d_config" >&2
       continue
     fi
-    if [[ -z $modules ]]; then
+    if [[ -z $d_modules ]]; then
       bdc_find_modules
-    elif [[ ! -d $modules ]]; then
+    elif [[ ! -d $d_modules ]]; then
       die 'ERROR: Discord modules directory not found.'
     fi
     break
@@ -305,12 +305,12 @@ bdc_scan() {
 }
 
 bdc_find_modules() {
-  [[ -d $discord_config ]] || die "ERROR: Discord $flavor config directory not found ($discord_config)."
-  declare -a all_modules
-  all_modules=("$discord_config/"+([0-9]).+([0-9]).+([0-9])/modules)
-  ((${#all_modules[@]})) || die 'ERROR: Discord modules directory not found.'
-  modules=${all_modules[-1]}
-  verbose 1 "V: Found modules in $modules"
+  [[ -d $d_config ]] || die "ERROR: Discord $d_flavor config directory not found ($d_config)."
+  declare -a all_d_modules
+  all_d_modules=("$d_config/"+([0-9]).+([0-9]).+([0-9])/modules)
+  ((${#all_d_modules[@]})) || die 'ERROR: Discord modules directory not found.'
+  d_modules=${all_d_modules[-1]}
+  verbose 1 "V: Found modules in $d_modules"
 }
 
 bdc_snap() {
@@ -318,7 +318,7 @@ bdc_snap() {
   # Expansion should happen inside snap's shell.
   xdg_config=$("$snap_bin" run --shell discord \
       <<< $'printf -- \'%s/.config\n\' "$SNAP_USER_DATA" 1>&3' 3>&1)
-  discord_config=$xdg_config/discord
+  d_config=$xdg_config/discord
   bd_config=$xdg_config/BetterDiscord
   bd_asar_dest=$bd_config/data/betterdiscord.asar
   bdc_find_modules
@@ -329,15 +329,15 @@ bdc_flatpak() {
   # Expansion should happen inside flatpak's shell.
   xdg_config=$("$flatpak_bin" run --command=sh com.discordapp.Discord \
       -c $'printf -- \'%s\n\' "$XDG_CONFIG_HOME"')
-  discord_config=${xdg_config:-$HOME/.var/app/com.discordapp.Discord/config}/discord
+  d_config=${xdg_config:-$HOME/.var/app/com.discordapp.Discord/config}/discord
   bd_config=$xdg_config/BetterDiscord
   bd_asar_dest=$bd_config/data/betterdiscord.asar
   bdc_find_modules
 }
 
 bdc_kill() {
-  printf 'Killing Discord %s processes...\n' "$flavor" >&2
-  pkill -exi -KILL "discord${flavor:0:8}" || printf 'No active processes found.\n' >&2
+  printf 'Killing Discord %s processes...\n' "$d_flavor" >&2
+  pkill -exi -KILL "discord${d_flavor:0:8}" || printf 'No active processes found.\n' >&2
 }
 
 bd_install_asar() {
@@ -357,18 +357,18 @@ bd_install_asar() {
 }
 
 bdc_clean_legacy() {
-  if [[ -d $core/core ]]; then
+  if [[ -d $d_core/core ]]; then
     printf 'Removing legacy core directory...\n' >&2
-    rm -rf "$core/core"
+    rm -rf "$d_core/core"
   fi
-  if [[ -d $core/injector ]]; then
+  if [[ -d $d_core/injector ]]; then
     printf 'Removing legacy injector directory...\n' >&2
-    rm -rf "$core/injector"
+    rm -rf "$d_core/injector"
   fi
-  if [[ -d $data ]]; then
-    if [[ -f "$data/bd_map" || -d "$data/bd" ]]; then
+  if [[ -d $bdc_data ]]; then
+    if [[ -f "$bdc_data/bd_map" || -d "$bdc_data/bd" ]]; then
       printf 'Removing legacy machine-specific data...\n' >&2
-      rm -rf "$data/bd_map" "$data/bd"
+      rm -rf "$bdc_data/bd_map" "$bdc_data/bd"
     fi
   fi
 }
@@ -378,13 +378,13 @@ bd_patch() {
   declare escaped_asar=${bd_asar_dest/\\/\\\\}
   printf $'require("%s");
 module.exports = require(\'./core.asar\');
-' "${escaped_asar//\"/\\\"}" > "$core/index.js"
+' "${escaped_asar//\"/\\\"}" > "$d_core/index.js"
 }
 
 bd_unpatch() {
   verbose 1 'V: Removing BetterDiscord injection...'
   printf $'module.exports = require(\'./core.asar\');
-' > "$core/index.js"
+' > "$d_core/index.js"
 }
 
 # Included from https://github.com/bb010g/Semver.sh , under the MIT License.

--- a/betterdiscordctl
+++ b/betterdiscordctl
@@ -88,7 +88,11 @@ die_with_help() {
   die "$@" 'Use "--help" for more information.'
 }
 
-die_non_empty() {
+die_option() {
+  die_with_help "ERROR: \"$1\" requires an option argument."
+}
+
+die_non_empty_option() {
   die_with_help "ERROR: \"$1\" requires a non-empty option argument."
 }
 
@@ -109,74 +113,74 @@ while :; do
       ((++verbosity))
       ;;
     -s|--scan)
-      if [[ ${2+x} ]]; then IFS=':' read -ra scan <<< "$2"; shift
-      else die_non_empty "$1"; fi
+      if [[ ${2:+x} ]]; then IFS=':' read -ra scan <<< "$2"; shift
+      else die_non_empty_option "$1"; fi
       ;;
     --scan=?*)
       IFS=':' read -ra scan <<< "${1#*=}"
       ;;
     --scan=)
-      die_non_empty "${1%%=*}"
+      die_non_empty_option "${1%%=*}"
       ;;
     -f|--flavors)
-      if [[ ${2+x} ]]; then IFS=':' read -ra flavors <<< "$2"; shift
-      else die_non_empty "$1"; fi
+      if [[ ${2:+x} ]]; then IFS=':' read -ra flavors <<< "$2"; shift
+      else die_non_empty_option "$1"; fi
       ;;
     --flavors=?*)
       IFS=':' read -ra flavors <<< "${1#*=}"
       ;;
     --flavors=)
-      die_non_empty "${1%%=*}"
+      die_non_empty_option "${1%%=*}"
       ;;
     -d|--discord)
-      if [[ ${2+x} ]]; then discord=$2; shift
-      else die_non_empty "$1"; fi
+      if [[ ${2:+x} ]]; then discord=$2; shift
+      else die_non_empty_option "$1"; fi
       ;;
     --discord=?*)
       discord=${1#*=}
       ;;
     --discord=)
-      die_non_empty "${1%%=*}"
+      die_non_empty_option "${1%%=*}"
       ;;
     -m|--modules)
-      if [[ ${2+x} ]]; then modules=$2; shift
-      else die_non_empty "$1"; fi
+      if [[ ${2:+x} ]]; then modules=$2; shift
+      else die_non_empty_option "$1"; fi
       ;;
     --modules=?*)
       modules=${1#*=}
       ;;
     --modules=)
-      die_non_empty "${1%%=*}"
+      die_non_empty_option "${1%%=*}"
       ;;
     --bd-repo-branch)
-      if [[ ${2+x} ]]; then bd_repo_branch=$2; shift
-      else die_non_empty "$1"; fi
+      if [[ ${2:+x} ]]; then bd_repo_branch=$2; shift
+      else die_non_empty_option "$1"; fi
       ;;
     --bd-repo-branch=?*)
       bd_repo_branch=${1#*=}
       ;;
     --bd-repo-branch=)
-      die_non_empty "${1%%=*}"
+      die_non_empty_option "${1%%=*}"
       ;;
     -r|--bd-repo)
-      if [[ ${2+x} ]]; then bd_repo=$2; shift
-      else die_non_empty "$1"; fi
+      if [[ ${2:+x} ]]; then bd_repo=$2; shift
+      else die_non_empty_option "$1"; fi
       ;;
     --bd-repo=?*)
       bd_repo=${1#*=}
       ;;
     --bd-repo=)
-      die_non_empty "${1%%=*}"
+      die_non_empty_option "${1%%=*}"
       ;;
     -b|--betterdiscord)
-      if [[ ${2+x} ]]; then bd=$2; shift
-      else die_non_empty "$1"; fi
+      if [[ ${2:+x} ]]; then bd=$2; shift
+      else die_non_empty_option "$1"; fi
       ;;
     --betterdiscord=?*)
       bd=${1#*=}
       ;;
     --betterdiscord=)
-      die_non_empty "${1%%=*}"
+      die_non_empty_option "${1%%=*}"
       ;;
     -c|--copy-bd)
       copy_bd=yes
@@ -191,7 +195,7 @@ while :; do
       snap_bin=${1#*=}
       ;;
     --snap=)
-      die_non_empty "${1%%=*}"
+      die_non_empty_option "${1%%=*}"
       ;;
     --flatpak)
       flatpak=yes
@@ -203,7 +207,7 @@ while :; do
       flatpak_bin=${1#*=}
       ;;
     --flatpak=)
-      die_non_empty "${1%%=*}"
+      die_non_empty_option "${1%%=*}"
       ;;
     --nix)
       nix=yes
@@ -213,17 +217,17 @@ while :; do
       nix_store_bin=${1#*=}
       ;;
     --nix=)
-      die_non_empty "${1%%=*}"
+      die_non_empty_option "${1%%=*}"
       ;;
     --upgrade-url)
-      if [[ ${2+x} ]]; then upgrade_url=$2; shift
-      else die_non_empty "$1"; fi
+      if [[ ${2:+x} ]]; then upgrade_url=$2; shift
+      else die_non_empty_option "$1"; fi
       ;;
     --upgrade-url=?*)
       upgrade_url=${1#*=}
       ;;
     --upgrade-url=)
-      die_non_empty "${1%%=*}"
+      die_non_empty_option "${1%%=*}"
       ;;
     --)
       shift

--- a/betterdiscordctl
+++ b/betterdiscordctl
@@ -31,7 +31,7 @@ xdg_config=${XDG_CONFIG_HOME:-$HOME/.config}
 data=${XDG_DATA_HOME:-$HOME/.local/share}/betterdiscordctl
 snap_bin=snap
 flatpak_bin=flatpak
-nix_bin='nix-store'
+nix_store_bin='nix-store'
 
 show_help() {
   cat << EOF
@@ -210,7 +210,7 @@ while :; do
       ;;
     --nix=?*)
       nix=yes
-      nix_bin=${1#*=}
+      nix_store_bin=${1#*=}
       ;;
     --nix=)
       die_non_empty '--nix'
@@ -486,7 +486,7 @@ bdc_nix() {
     elif [[ ${flavor,,} == canary ]]; then
       flavor=Canary
     fi
-    scandir=$("$nix_bin" -r "$(which "Discord$flavor")")
+    scandir=$("$nix_store_bin" -r "$(which "Discord$flavor")")
     verbose 2 "VV: Scanning $scandir"
     discord="$scandir/opt/Discord$flavor"
     if [[ -d $discord ]]; then

--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,13 @@
+{ nixpkgs ? import <nixpkgs> { } }:
+
+nixpkgs.mkShell {
+  name = "bb010g-betterdiscordctl-shell";
+
+  # inputsFrom = [ ];
+  nativeBuildInputs = [
+    nixpkgs.shellcheck
+  ];
+  buildInputs = [
+    nixpkgs.bashInteractive
+  ];
+}


### PR DESCRIPTION
* Adapted the process for the new BetterDiscord beta (fixes #96).
* Incorporated the `update` command in `reinstall` (resolves #76).
* Removed `--scan` and `--discord` as we don't really need them.
* Removed `--nix` since the modules location isn't affected.
* Removed `--copy-bd` which was deemed unnecessary.
* Removed obsolete `bd_map_*` & `bd_injector` functions.
* Added new `bd_data` & `bd_asar` functions.
* Changed `--bd-repo-branch` to `--bd-repo-release`.
* Changed `--betterdiscord` to specify a custom `betterdiscord.asar`.
* Deprecated unused `$XDG_DATA_HOME/betterdiscordctl` directory.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bb010g/betterdiscordctl/120)
<!-- Reviewable:end -->
