### PR TITLE
Add install prompt to reinstall command when not installed

### DIFF
--- a/betterdiscordctl
+++ b/betterdiscordctl
@@ -337,8 +337,20 @@ bdc_install() {
   >&2 printf 'Installed. (Restart Discord if necessary.)\n'
 }
 
+bdc_install_prompt() {
+  echo -n "ERROR: Not installed. Install now? [Y/n] "
+  read ans
+
+  if [[ "$ans" = "Y" || "$ans" = 'y' ]]; then
+    bdc_install
+    exit
+  else
+    exit
+  fi
+}
+
 bdc_reinstall() {
-  grep -Fq "$bd_asar_name" "$d_core/index.js" || die 'ERROR: Not installed.'
+  grep -Fq "$bd_asar_name" "$d_core/index.js" || bdc_install_prompt
   bdc_clean_legacy
 
   bdc_kill


### PR DESCRIPTION
Added a prompt to install instead of dying when `betterdiscordctl reinstall` fails.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bb010g/betterdiscordctl/145)
<!-- Reviewable:end -->
