### PR TITLE
Fix structure for new Discord client configuration files

### DIFF
--- a/betterdiscordctl
+++ b/betterdiscordctl
@@ -399,7 +399,7 @@ bdc_self_upgrade() {
 bdc_main() {
   xdg_discover_config
   bdc_discover
-  d_core=$d_modules/discord_desktop_core
+  d_core=$d_modules/discord_desktop_core-1/discord_desktop_core
   [[ -d $d_core ]] || die "ERROR: Directory 'discord_desktop_core' not found in: $d_modules"
   bd_remote_init
   bd_asar=$bd_config/data/$bd_asar_name
@@ -443,7 +443,7 @@ bdc_find_modules() {
   else
     [[ -d $d_config ]] || die "ERROR: Discord $d_flavor config directory not found: $d_config"
     declare -a all_d_modules
-    all_d_modules=("$d_config/"+([0-9]).+([0-9]).+([0-9])/modules)
+    all_d_modules=("$d_config/app-"+([0-9]).+([0-9]).+([0-9])/modules)
     ((${#all_d_modules[@]})) || die 'ERROR: Discord modules directory not found.' \
         'Try specifying it with --d-modules.'
     d_modules=${all_d_modules[-1]}


### PR DESCRIPTION
Older Discord clients used a folder which matched the Regex in the script, but now the folder has a `app-` appended at the beginning. To fix the script entirely, change the line 

https://github.com/bb010g/betterdiscordctl/blob/49a26fe82d441fbb8e51b0511969929f05cb2057/betterdiscordctl#L402
to
```
d_core=$d_modules/discord_desktop_core-1/discord_desktop-core
```

as @Serverfrog said, and change line

https://github.com/bb010g/betterdiscordctl/blob/49a26fe82d441fbb8e51b0511969929f05cb2057/betterdiscordctl#L446
to
```
all_d_modules=("$d_config/app-"+([0-9]).+([0-9]).+([0-9])/modules)
```

as well, and everything will be fixed.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bb010g/betterdiscordctl/162)
<!-- Reviewable:end -->
